### PR TITLE
fix: Move Zobaidul Kazi listing above Zonayed Ahmed to maintain alpha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,5 +693,5 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 
 - [ZHENG Robert](https://www.robert.hase-zheng.net)
 - [Ziyad](https://ziyadsk.github.io/portfolio-V2)
+- [Zobaidul Kazi](https://zobkazi.github.io/)
 - [Zonayed Ahmed](https://zonayed.me)
-- [Zobaidul Kazi](https://zobkazi.github.io)


### PR DESCRIPTION
…betical order

This change updates the alphabetical order of the listings under the 'Z' section. Zobaidul Kazi is now listed above Zonayed Ahmed to ensure the list is correctly sorted.