### PR TITLE
Add portfolio links opener utility script

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,73 @@
+# Portfolio Link Opener 🔗
+
+A simple Python script that opens all portfolio links from the README.md file in your browser tabs automatically! No more clicking links one by one 😊
+
+## What does it do? 🤔
+
+Imagine you want to look at all the awesome portfolio websites in this repository. Instead of clicking hundreds of links manually, this script will:
+
+1. Read all the links from the README file
+2. Open each link in a new tab in your default browser
+3. Tell you how many links it opened
+
+## How to use it? 🚀
+
+### Step 1: Requirements
+
+- Make sure you have Python installed on your computer
+- Download the `portfolio_opener.py` script
+
+### Step 2: Run the script
+
+1. Put the script in the same folder as the README.md file
+2. Open your terminal/command prompt
+3. Navigate to the folder containing the script
+4. Run this command:
+   ```bash
+   python portfolio_opener.py
+
+
+   ```
+
+## Usage step by step
+
+1. Make sure you have Python installed on your system
+2. Navigate to the tools directory:
+
+   ```bash
+   cd tools
+
+   ```
+
+3. Run the script:
+
+   ```bash
+   portfolio_opener.py
+   ```
+
+4. Or specify a different markdown file:
+   ```
+   portfolio_opener.py -f ../README.md
+   ```
+
+## ⚠️ Important Notes
+
+### About Opening Links
+
+- This script opens all links from README.md in your default browser
+- Opening too many links at once may slow down your browser or cause it to crash
+- We recommend opening no more than 50 links at a time
+- Keep the links in a file based on how many you want to open. For example, if you want to open 30 links, just add 30 links to the file. If you want 50, add 50 links, and so on
+- If your computer can handle more tabs, feel free to open more!
+
+### Browser Tips
+
+- Your browser might ask permission to open multiple tabs
+- If your browser slows down, just close some tabs and try again
+- This is completely normal - don't worry!
+
+### Recommendation
+
+Start with 50 tabs first. If your computer handles it well, you can try opening more next time.
+
+### 🎉 Have fun exploring all the amazing portfolios for inspiration!

--- a/tools/portfolio_opener.py
+++ b/tools/portfolio_opener.py
@@ -1,0 +1,50 @@
+import re
+import webbrowser
+import argparse
+import sys
+from pathlib import Path
+
+def open_portfolio_links(file_path):
+    """
+    Opens all portfolio links found in the given markdown file in new browser tabs.
+    
+    Args:
+        file_path (str): Path to the markdown file containing portfolio links
+    """
+    try:
+        # URL pattern to match the url link in mark down file
+        url_pattern = re.compile(r'https?://\S+?(?=\)|\])|https?://\S+')
+        
+        # Reads the file
+        with open(file_path, "r", encoding="utf-8") as file:
+            content = file.read()
+            urls = url_pattern.findall(content)
+        
+        # Open URLs
+        for url in urls:
+            webbrowser.open_new_tab(url)
+        
+        print(f"Successfully opened {len(urls)} links in your default browser :`).")
+        
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        sys.exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Open all portfolio links from the developer-portfolios README in your browser."
+    )
+    parser.add_argument(
+        "-f", "--file",
+        default="../README.md",
+        help="Path to the markdown file containing portfolio links (default: ../README.md)"
+    )
+    
+    args = parser.parse_args()
+    open_portfolio_links(args.file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script helps users open portfolio links easily!

## Problem
Currently, users need to manually click each portfolio link to view them, which can be time-consuming when trying to browse through multiple portfolios for inspiration.

## Solution
Added a Python script that automatically opens all portfolio links in new browser tabs.

### What it does:
- Opens all portfolio links from README.md in browser tabs
- Saves time instead of clicking links one by one
- Includes warnings about opening too many tabs
- Works with Python 3.8+

How to use:
1. Go to tools folder
2. Run the script: python portfolio_opener.py
3. Browser tabs will open with portfolio websites

I've tested it on my computer and it works well!
