### PR TITLE
Removed duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 
 ## A
 
-- [Aaban Malik](https://muhammadaamirmalik.com/)
 - [Aabar Khan](https://aabaarkhan.quippedai.com/)
 - [Aabid Ahmed](https://sawad.framer.website/)
 - [Aabraham James](https://seera.framer.website/)
@@ -52,7 +51,6 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Abhishek Panthee](https://abhishekpanthee.com.np)
 - [Abhishek Singh](https://www.abhishekworks.com/) [Full-Stack developer]
 - [Abu Said](https://www.abusaid.me)
-- [Abu Suhaib](https://suhaib.protool.co.in) [Full-Stack WebnApp Developer]
 - [Abubakr Mufutau-Oseni](https://abubakrmo.com)
 - [Adam Alston](https://www.adamalston.com)
 - [Adeola Badero](https://www.adeolabadero.me) [Frontend Engineer & UI/UX Designer]
@@ -159,7 +157,6 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Arup Mandal](https://arupmandal.github.io)
 - [Asad Shah](https://iamasadshah-ibnerafi.vercel.app)
 - [Asfakur Nariz](https://asfakur-portfolio-nextjs.vercel.app) [Front-end Developer || UI/UX Designer || Full Stack Developer]
-- [Asfakur Nariz](https://asfakur-portfolio-nextjs.vercel.app/)
 - [Ashak Zahin Hasan](https://aboutzahin.pages.dev)
 - [Ashikur Rahaman](https://portfolio-by-ashik.netlify.app/)
 - [Ashish Mehra](https://ashishmehra.dev)
@@ -271,7 +268,6 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Cristian Cezar Moisés](https://ccm.securityops.com.br)
 - [Cristiano Filho](https://cristianofilho.github.io)
 - [Cui Ding](https://cuierd.github.io)
-- [codervai](https://codervai.vercel.app)
 
 ## D
 
@@ -295,7 +291,6 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Debasish Dutta](https://debasishdutta.is-a.dev)
 - [Deepak Singh](https://deepaksingh.vercel.app)
 - [Delba](https://delba.dev)
-- [Demon142](https://demon142.net)
 - [Demon142](https://demon142.net)
 - [Denis Tokarev](https://devlato.com)
 - [Dennis Cristian](https://denncriss.com)


### PR DESCRIPTION
1. URL-Only Duplicates

- Aaban Malik vs. Aamir Malik
Both link to: https://muhammadaamirmalik.com/, kept Aamir as shown on linked site.

- Abu Suhaib vs. Suhaib SZ,
Both link to: https://suhaib.protool.co.in, kept Suhaib SZ as shown on site.

2. Name and URL Duplicates

- Asfakur Nariz
Defers by trailing slash and titles. Kept copy with extra titles.
- Demon142
Complete duplicate.
- codervai
Defer by case only, kept the copy that was in alphabetical order

