### PR TITLE
Add Ghulam Mujtaba portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo was inspired by [Ali Spittel'S](https://twitter.com/ASpittel) tweet
 
 Hopefully this repo can serve as a source of inspiration for your portfolio!
 
-## Current Portfolio Count: 1247
+## Current Portfolio Count: 1248
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -497,6 +497,7 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Ghom Krosmonaute](https://ghomkrosmonaute.github.io/?game)
   ([@Ghomkrosmonaute](https://github.com/GhomKrosmonaute))
 - [Ghulam Ahmed](https://gahmed.com)
+- [Ghulam Mujtaba](https://ghulammujtaba.com)
 - [Gianluca Fiore](http://gianlucafiore.it)
 - [Gianluca Galota](https://gianlucagalota.dev)
 - [Gil Itzhaky - Gilitz](https://gilitz.com) ([Interactive 3D Protfolio Game] - Frontend Developer)


### PR DESCRIPTION
Adding my portfolio https://ghulammujtaba.com to the developer portfolios list.

- Added portfolio entry in alphabetical order in the G section
- Updated portfolio count from 1247 to 1248
- Follows all contribution guidelines