### PR TITLE
Add John Ryan Cottam to portfolio list

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Jo Lienhoop](https://jolienhoop.com)
 - [John Doe](https://portfolio-john2.netlify.app)
 - [John Petalio](https://johnreypetalio.netlify.app)
+- [John Ryan Cottam](https://johnryancottam.com)
 - [Johnny Chai](https://johnnychai.com) [Web Developer]
 - [Jonas Werner](https://jonaswerner.com)
 - [Jonathan Peters](https://github.com/QMS85/MyPortfolio) [Front End Developer]


### PR DESCRIPTION
Included John Ryan Cottam's portfolio link in the README's list of example portfolios.



**Reminder.**
Please make sure your new listing is added to the README in alphabetical order, by your first name.


