### PR TITLE
Add Raymond Valdepeñas to portfolio list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,7 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Ramiz](https://my-portfolio-pied-xi.vercel.app)
 - [Rasyid Nuruddin](https://thesimpanze.github.io/Portofolio-Rasyid) [Front-End Developer]
 - [Ratnesh Patil](https://ratanesh-patil.github.io/portfolioratnesh)
+- [Raymond Valdepeñas](https://raymondvaldepenas-dev.vercel.app)[Full Stack Developer | AIoT & Embedded Systems | Junior Software Engineer]
 - [Raymond Valencia](https://paolo1231.github.io)
 - [Raziel Rodrigues](https://www.razielrodrigues.dev)
 - [Razin Rayees](https://www.razinrayees.com)


### PR DESCRIPTION
Included Raymond Valdepeñas with portfolio link and role in the README's inspiration section.



**Reminder.**
Please make sure your new listing is added to the README in alphabetical order, by your first name.


