### PR TITLE
docs: add Nyamboga Hezron to the list of developer portfolios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,7 @@ This repo can serve as a source of inspiration for your portfolio!
 - [Nsk Reddy](https://nskr.dev) [Student | Freelancer | Aspiring Ai Engineer]
 - [Nurliman Diara](https://nurliman.dev)
 - [Nuwan Jaliyagoda](http://nuwanjaliyagoda.com)
+- [Nyamboga Hezron](https://www.nyambogahezron.dev/) [Full Stack Developer | React, Node.js, TypeScript]
 
 ## O
 


### PR DESCRIPTION

 I have added my portfolio to the 
README.md
 file under the 'N' section, ensuring it follows the existing alphabetical order.

