### PR TITLE
Add Shawn Kurtnelle Lewis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1490,6 +1490,7 @@ This repo can serve as inspiration for your portfolio!
 - [Shashi Kant](https://shashikantportfolio.web.app) [Full Stack Developer]
 - [Shaun Furtado](https://shaunfurtado.is-a.dev)
 - [Shaurya Chandhoke](https://shauryachandhoke.com/?utm_source=github&utm_medium=social&utm_campaign=portfolio) [Software Engineer | Machine Learning Engineer]
+- [Shawn Kurtnelle Lewis](https://shawnklewis.com) [Augmented Software Engineer | Systems Architect]
 - [Shefali](https://shefali.dev)
 - [Sheljin](https://shelj.in) [Full Stack Developer]
 - [Shihablabs](https://shihablabs.vercel.app) [Full Stack Developer / Software Engineer]


### PR DESCRIPTION
Adding my portfolio, inserted alphabetically between "Shaurya Chandhoke" and "Shefali", per CONTRIBUTING.md (`- [Name](portfolio-link) [Title | Expertise]`):

- [Shawn Kurtnelle Lewis](https://shawnklewis.com) [Augmented Software Engineer | Systems Architect]

### Context: this is a re-add

This entry was previously added and **merged** in #3644 (merged 2026-05-14, as "Shawn K. Lewis — Software Engineer"). However, the merge commit for #3644 is no longer reachable from the current `master` — `master` was subsequently force-rewritten (the periodic link-update/rebase pass), which dropped the merged entry along with its merge commit.

This PR re-adds it cleanly on top of current `master` (single commit, no conflicts) and updates the title to its current form.

Heads-up for maintainers: the same history rewrite appears to have silently dropped other previously-merged entries too, not just this one — worth checking if merge-time rewrites are clobbering accepted contributions.