### PR TITLE
Add Qihang Feng portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,7 @@ This repo can serve as inspiration for your portfolio!
 
 ## Q
 
+- [Qihang Feng](https://qfeng.beaverexp.com) [Software Engineering Student | Full Stack Development, Machine Learning]
 - [Qui Nguyen](https://www.lexnguyen.dev)
 - [Quint Wessels](https://quintwessels.com)
 


### PR DESCRIPTION
Added **Qihang Feng** portfolio website to the developer portfolios list.
The entry was added under the **Q section** in alphabetical order by first name.

