### PR TITLE
Fix bare except clause in src/alphabetical.py (fixes #3718)

### DIFF
--- a/src/alphabetical.py
+++ b/src/alphabetical.py
@@ -151,7 +151,7 @@ def validate_section_placement(lines):
                 try:
                     normalized = unicodedata.normalize('NFD', first_char)
                     base_char = normalized[0] if normalized else first_char
-                except:
+                except Exception:
                     base_char = first_char
 
                 # If not a letter A-Z, keep in current section


### PR DESCRIPTION
## What

Replaces the bare `except:` clause in `src/alphabetical.py` (line 154) with `except Exception:`.

## Why

Bare `except:` clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which is almost never the intended behavior. Using `except Exception:` is the Python best practice as it catches all "normal" exceptions while allowing system-level exceptions to propagate.

## Changes

- `src/alphabetical.py`: `except:` → `except Exception:`

Closes #3718