### PR TITLE
fix: replace bare except clause in src/alphabetical.py

### DIFF
--- a/src/alphabetical.py
+++ b/src/alphabetical.py
@@ -151,7 +151,7 @@ def validate_section_placement(lines):
                 try:
                     normalized = unicodedata.normalize('NFD', first_char)
                     base_char = normalized[0] if normalized else first_char
-                except:
+                except Exception:
                     base_char = first_char
 
                 # If not a letter A-Z, keep in current section


### PR DESCRIPTION
## Summary

- Replaces bare `except:` at line 154 of `src/alphabetical.py` with `except Exception:`
- Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — exceptions that should never be silently swallowed
- `except Exception:` is the correct Python idiom (PEP 8 / flake8 E722 / Pylint W0702)

Closes #3718

## Test plan

- [ ] Confirm `src/alphabetical.py` runs without errors
- [ ] Verify existing CI/pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)