### PR TITLE
Add PR submission checklist to CONTRIBUTING.md and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 
+**Submission Checklist**
 
-**Reminder.**
-Please make sure your new listing is added to the README in alphabetical order, by your first name.
+Please confirm the following before submitting your PR:
 
-
+- [ ] I have opened my portfolio link in a browser and it loads correctly — it does **not** redirect to a domain parking/sale page or return an error.
+- [ ] My entry is added in **strict alphabetical order** by first name.
+- [ ] I have **not** edited `feed.json` — it is auto-generated and will be updated automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,19 @@
     ### Result
     - [Itachi Uchiha](https://naruto.fandom.com/wiki/Itachi_Uchiha) [Anbu Captain | Legend]
 
-5. Commit changes and push the new branch.
-6. Open and submit a PR.
+5. Verify your submission meets the checklist below.
+6. Commit changes and push the new branch.
+7. Open and submit a PR.
+
+### PR Submission Checklist
+
+Before opening a pull request, confirm each of the following:
+
+- [ ] I have opened my portfolio link in a browser and it loads correctly — it does **not** redirect to a domain parking/sale page or return an error.
+- [ ] My entry is added in **strict alphabetical order** by first name.
+- [ ] I have **not** edited `feed.json` — it is auto-generated and will be updated automatically.
+
+> **Note on the automated link checker:** A scheduled workflow runs every Saturday to verify all links in the repo. Broken or parked links are flagged and removed. You can view a sample broken link report [here](https://github.com/emmabostian/developer-portfolios/issues/3696).
 
 If you have never opened a PR and need direction, read more below.
 


### PR DESCRIPTION
## Summary

- Adds a **PR Submission Checklist** section to `CONTRIBUTING.md` with three items: link verification, alphabetical order, and a note not to edit `feed.json`
- Updates the **pull request template** (`.github/pull_request_template.md`) with the same checklist so contributors see it when opening a PR
- Includes a note about the automated Saturday link checker with a link to a sample broken link report

Closes #3763

🤖 Generated with [Claude Code](https://claude.com/claude-code)