### PR TITLE
Remove 3 broken portfolio links (fixes #3802)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1778
+## Current Portfolio Count: 1775
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -692,7 +692,6 @@ Extension]
 - [Ghulam Mujtaba](https://ghulammujtaba.com)
 - [Gianluca Fiore](http://gianlucafiore.it)
 - [Gianluca Galota](https://gianlucagalota.dev)
-- [Gii-DE](https://gii-de.onrender.com) [Creative Engineer | AI, Web, Security & Custom Design]
 - [Gil Itzhaky Gilitz](https://gilitz.com) - `Interactive 3D Protfolio Game` [Frontend Developer]
 - [Giorgio Faini](https://giorgiofaini.com)
 - [Glen Elric Fernandes](https://www.glenelric.space) [Full Stack SDE| Data Science Researcher| Student]
@@ -1076,7 +1075,6 @@ Extension]
 - [Md Rashid](https://md-rashid.vercel.app) [Software Developer]
 - [Md Sarfaraz Alam](https://mdsaifedu.eu.cc/3D-portfolio/) [Full Stack DevOps Engineer]
 - [Md Usman Ansari](https://mdusmanansari.netlify.app)
-- [Mees Verberne](https://meesverberne.com) [Creative Frontend Developer & Designer]
 - [Meet Prajapati](https://meetprajapati.com) [Lead Mobile Engineer | Android, AI, Flutter, React Native]
 - [Mehdi Ali](https://exoo25.github.io)
 - [Mehedi Hasan](https://m-hasan.vercel.app) [Frontend Developer]
@@ -1270,7 +1268,6 @@ Extension]
 - [Patrick Hyatt](https://www.patrickhyatt.com)
 - [Patrick Müller](https://p-mueller.dev) [Software Developer]
 - [Patrick Obermeier](https://www.patrickobermeier.at)
-- [Patrick Reid](http://iamreliq.com)
 - [Paul Henry Atienza](https://www.paulatienza.dev) [Software Engineer | Enterprise Java Developer]
 - [Paul Koeck](https://paul.koeck.dev)
 - [Paul Pietzko](https://www.paulpietzko.com)

--- a/feed.json
+++ b/feed.json
@@ -2913,11 +2913,6 @@
     "url": "https://gianlucagalota.dev"
   },
   {
-    "name": "Gii-DE",
-    "url": "https://gii-de.onrender.com",
-    "tagline": "Creative Engineer | AI, Web, Security & Custom Design"
-  },
-  {
     "name": "Gil Itzhaky Gilitz",
     "url": "https://gilitz.com"
   },
@@ -4558,11 +4553,6 @@
     "url": "https://mdusmanansari.netlify.app"
   },
   {
-    "name": "Mees Verberne",
-    "url": "https://meesverberne.com",
-    "tagline": "Creative Frontend Developer & Designer"
-  },
-  {
     "name": "Meet Prajapati",
     "url": "https://meetprajapati.com",
     "tagline": "Lead Mobile Engineer | Android, AI, Flutter, React Native"
@@ -5380,10 +5370,6 @@
   {
     "name": "Patrick Obermeier",
     "url": "https://www.patrickobermeier.at"
-  },
-  {
-    "name": "Patrick Reid",
-    "url": "http://iamreliq.com"
   },
   {
     "name": "Paul Henry Atienza",


### PR DESCRIPTION
## Summary

Removes 3 portfolio entries flagged in issue #3802 with 404/503 errors:

| Name | URL | Reason |
| ---- | --- | ------ |
| Gii-DE | https://gii-de.onrender.com | 503 Service Unavailable |
| Mees Verberne | https://meesverberne.com | 503 Service Unavailable |
| Patrick Reid | http://iamreliq.com | 404 Not Found |

Other errors from the issue were already removed in #3809. Timeout entries (heny.dev, matheusmisumoto.dev) intentionally skipped.

Closes #3802

🤖 Generated with [Claude Code](https://claude.ai/claude-code)