### PR TITLE
Remove 5 broken portfolio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1775
+## Current Portfolio Count: 1790
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -467,7 +467,6 @@ Extension]
 - [Chuckz Okoye](https://chuckzokoye.com)
 - [Chung Nguyen Thanh Chunhthanhde](https://chunhthanhde.github.io)
 - [Cian Goon](https://ciangoon.dev) [Software Engineer, Quant Developer]
-- [Cid Kageno](https://www.mritunjoy.online) [Full Stack Developer]
 - [Ciro Ciampaglia](https://cirociampaglia.it)
 - [Claudia Freitas](https://icfclaudia.com) [Product Owner | Project Manager | Digital Marketer]
 - [Cleo Balaranjith](https://cleof.us) [SITE bearly wOrKs DONT OPEN it🐺✌️🪫 | brainde*d developer]
@@ -709,7 +708,7 @@ Extension]
 - [Gowtham Sridhar](https://www.gowthamsridhar.com) [AI engineer, HCI Scientist + robots]
 - [Grace Snow](https://gracesnowdesign.co.uk)
 - [Greta Macri](https://gretamacri.com)
-- [Guna Teja S P](https://tejafolio.dev/) [AI ML Student]
+- [Guna Teja](https://tejafolio.dev) [AI ML Student]
 - [Gunasree](https://gunasree-portfolio.vercel.app) [AI Engineer | Technical Expertise]
 - [Gunjan Ghate](http://techggdev.vercel.app) - [Full Stack Web2/Web3 Developer]
 - [Gustavo Gutierrez](https://gutierrez-cv.vercel.app) - [Fullstack/Ai&Ml Developer]
@@ -723,8 +722,8 @@ Extension]
 - [Hamish Williams](https://hamishw.com)
 - [Hamza Ehsan](https://www.hamzaehsan.com)
 - [Hamza Naseem](https://hamzanaseem.vercel.app)
-- [Hanif Yuli Abdillah](https://hanifabdlh.vercel.app) [Ai Software Engineer And Data Science]
 - [Hangga Aji Sayekti](https://hangga.web.id) [Software Engineer · Security Researcher · Tech Author]
+- [Hanif Yuli Abdillah](https://hanifabdlh.vercel.app) [Ai Software Engineer And Data Science]
 - [Hansana Prabath](https://hansana.is-a.dev)
 - [Hanumant Jain](https://hanumantjain.tech) [Software Developer | Full Stack Developer]
 - [Hanzla Tauqeer](https://github.com/1hanzla100/developer-portfolio)
@@ -839,7 +838,6 @@ Extension]
 - [Jeff Cardinal](https://jeffcardinal.com) [Software Engineer | Designer]
 - [Jeff Chiu](https://jeffchiucp.github.io/portfolio)
 - [Jens Van Wijhe](https://www.beterbekend.nl)
-- [Jenul Ferdinand](https://jenulferdinand.dev) [Software Engineer | Bcompsci 26' At Monash University]
 - [Jeremiah Haastrup](https://jeremiahhaastrup.com)
 - [Jeremy Erik Leong](https://www.jeremyerikleong.com)
 - [Jeremy Grifski](https://jeremygrifski.com)
@@ -963,12 +961,12 @@ Extension]
 
 ## L
 
+-  [Lalith Kumar](https://lalith-d-portfolio.netlify.app) [ AI Engineer | Data Scientist | Machine Learning Engineer]
+-  [Lalith](https://portfolic.vercel.app/lalithdabilpuram01) [ Data Scientist]
 - [Laercio Rios](https://laerciorios.com) [Full Stack Developer | Software Engineer]
 - [Lai Huishan](https://shan-verse.com) [Full Stack Developer | Master Student]
 - [Lakshan Rukantha](https://lakshanrukantha.github.io)
 - [Lakshya Jain](https://port-folio-nine-lemon-27.vercel.app) [For Any Developer | Has Multiple Templates | Semi - Automated Data Update Feature]
--  [Lalith Kumar](https://lalith-d-portfolio.netlify.app) [ AI Engineer | Data Scientist | Machine Learning Engineer]
--  [Lalith ](https://portfolic.vercel.app/lalithdabilpuram01) [ Data Scientist ]
 - [Lamine Neggazi](https://lamine.cc) [Full Stack Developer | Algiers]
 - [Lampard Kipyegon](https://lampard.netlify.app) [Data Scientist | AI/ML Engineer | Full Stack Dev | Scikit-learn, Numpy, Pandas, Matplotlib, Django etc. | Kenya]
 - [Larry Xue](https://larryxue.dev)
@@ -1017,7 +1015,7 @@ Extension]
 - [Mahatab Hossen Sudip](https://sudipmhx.pro.bd) [MERN Stack Developer]
 - [Mahdi Hasan](https://mahdihasan.space) [Software Engineer]
 - [Mahdi.Is-A.Dev](http://mahdi.is-a.dev)
-- [Mahin Hasan](https://mahin527.vercel.app/) [Shopify Expert | Full Stack Web Developer ]
+- [Mahin Hasan](https://mahin527.vercel.app) [Shopify Expert | Full Stack Web Developer]
 - [Mahmoud Nabhan](https://mahmoudnabhan.com)
 - [Mahmoud Zalt](https://zalt.me) [Full Stack Engineer | Software Architect | Ai Engineer | Tech Consultant | Mentor]
 - [Mahtab Ahmad](https://portfolio-1-0xhg.onrender.com) [Machine Learning Engineer]
@@ -1150,7 +1148,6 @@ Extension]
 - [Muhammad Faheem Iqbal Faheem506Pk](https://faheem506pk.vercel.app) [Frontend Developer | Mern Stack Developer | Iot Enthusiast]
 - [Muhammad Furqan](https://iammuhammadfurqan.github.io/portfolio/) [Full Stack AI Engineer | RAG & Voice AI Specialist]
 - [Muhammad Hassan Nazar](https://hassannazar72.github.io/portfolio/)
-- [Muhammed Ijlan](https://ijlan.dev)
 - [Muhammad Iqbal Nazulis](https://iqbalnzls.github.io/portfolio/) [Software Engineer | Backend]
 - [Muhammad Jahanzeb](https://jahanzeb.dev) [Mobile App Developer | React Native | Expo | Kotlin | NodeJS]
 - [Muhammad Muhaddis](https://muhaddis.info)
@@ -1158,10 +1155,11 @@ Extension]
 - [Muhammad Mustafiz Rahman](https://mustafizrahman.vercel.app) [Frontend Developer | Mern Stack Developer]
 - [Muhammad Rashid](https://iamrashy.netlify.app)
 - [Muhammad Saqib Atif](https://msaqibatifj.vercel.app) [AI/ML Engineer | Full Stack Developer]
-- [Muhammad Taha Nawab](https://taha-nawab-portfolio.vercel.app) [Full-Stack Developer · AI/ML Engineer]
+- [Muhammad Taha Nawab](https://taha-nawab-portfolio.vercel.app) [Full Stack Developer · AI/ML Engineer]
 - [Muhammad Tayyab](https://iamtayyab.com) [Full Stack Software Engineer]
 - [Muhammad Tufail Ahmed Khan](https://tufail.dev) [Lead Engineer | AI Engineer]
 - [Muhammad Ubaid Raza](https://mubaidr.js.org) [Sr. Software Engineer | Full Stack Developer | Chrome Extension Expert]
+- [Muhammed Ijlan](https://ijlan.dev)
 - [Muhammet Fatih Di̇Nç](https://mfatihdinc.com)
 - [Mukesh](https://themukesh.com) [Java,React, next.js, Full Stack Developer]
 - [Mukul Chugh](https://mukulchugh.com)
@@ -1298,7 +1296,7 @@ Extension]
 - [Phat Tran Tan](https://portfolio-ttp.vercel.app) [Software Engineer | Frontend Developer]
 - [Philip Johnson](https://philipmjohnson.org)
 - [Philipe Almeida](https://palmeida.netlify.app)
-- [Philippe Fanaro](https://aquarifolio.vercel.app/) [Full Stack Developer]
+- [Philippe Fanaro](https://aquarifolio.vercel.app) [Full Stack Developer]
 - [Phpxcoder](https://phpxcoder.in)
 - [Phyo Min Thein](https://phyominthein.com) [Full Stack Developer | AI Engineer]
 - [Pierre Nel](https://pierre.io) [Full Stack Developer | Ux/Ui Designer]
@@ -1635,7 +1633,6 @@ Extension]
 - [Sourabh Kothari](https://sourabhkothari.vercel.app)
 - [Sourav Dey](https://souravdey.space)
 - [Sourav Dutta](http://i-am-souravdutta.firebaseapp.com)
-- [Sparsh Kamat](http://sparshkamat.me) [Full Stack Web Developer]
 - [Sree Godavarthi](http://sreegodavarthi.github.io)
 - [Sreenitya Thatikunta](https://portfolio-sreenitya.vercel.app)
 - [Sri Anjaneyam](https://srianjaneyam.me)
@@ -1682,7 +1679,6 @@ Extension]
 ## T
 
 - [Tadashi Amano](https://tadashiamano.vercel.app)
-- [Taha Nawab](https://taha-nawab-portfolio.vercel.app/) [Full-Stack Developer · AI/ML Engineer]
 - [Taiizor](https://github.com/Taiizor) [.Net Developer]
 - [Talha Kılıç](https://talhakilic.com.tr) [Junior Frontend Developer]
 - [Tanay Shah](https://tanayshah.dev) [AI Engineer | Agent Infrastructure · Founding-Engineer Reps · NYC]
@@ -1844,7 +1840,7 @@ Extension]
 ## Y
 
 - [Yagyaraj Lodhi](https://yagyaraj.com) [Full Stack AI Developer]
-- [Yaksh Bambhroliya](https://yakshcore.vercel.app/) [Full Stack Developer]
+- [Yaksh Bambhroliya](https://yakshcore.vercel.app) [Full Stack Developer]
 - [Yared Tekileselassie](https://yared.vercel.app)
 - [Yaroslav Lebedenko](https://portfolio-nailheart.vercel.app)
 - [Yash Datir](https://yashdatir.github.io/profile-os)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1790
+## Current Portfolio Count: 1788
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -411,7 +411,6 @@ This repo can serve as inspiration for your portfolio!
 - [Brad Myrick](https://kodr.pro) [Blockchain/Backend Engineer]
 - [Brady Macdonald](https://bradymacdonald.com) [Full Stack Developer]
 - [Brandon Mitchell](https://juncie.com) [Full Stack Developer]
-- [Breakerino](https://breakerino.me) [Full Stack Web Developer]
 - [Brendan Lentz](https://brendanlentz.com)
 - [Brendon Van Zanten](https://brendonvanzanten.com) [Full Stack Developer]
 - [Brhane Giday](https://brhane.vercel.app) [Software Engineer | AI Engineer]
@@ -747,7 +746,6 @@ Extension]
 - [Hemang Yadav](https://zemerik.vercel.app) [Passionate Developer]
 - [Hemanth Chakravarthy Kancharla](https://hemanth-chakravarthy.netlify.app) [Engineering Student | Full Stack Developer]
 - [Henry Lee](https://dragonwarrior.vercel.app)
-- [Heny](https://heny.dev) [Full Stack Developer | Mern | Next.Js]
 - [Herman Starikov](http://starikov.dev)
 - [Herve Mbilo](https://diliwo.github.io) [Cloud-Native Software Engineer]
 - [Hesbon Angwenyi](https://hezy.netlify.app) [Full Stack Developer | DevOps Engineer]

--- a/feed.json
+++ b/feed.json
@@ -532,6 +532,11 @@
     "url": "https://ahmadawais.com"
   },
   {
+    "name": "Ahmad Faraz",
+    "url": "https://theahmadfaraz.com",
+    "tagline": "Full Stack Developer"
+  },
+  {
     "name": "Ahmed Abdelhafiez",
     "url": "https://nevo.is-a.dev",
     "tagline": "Front-End Web Developer"
@@ -1494,6 +1499,11 @@
     "tagline": "Software Developer - Full Stack"
   },
   {
+    "name": "Azwad Fawad Hasan",
+    "url": "https://azwadfawadhasan.github.io/resume/",
+    "tagline": "SWE | Researcher | Tech Enthusiast"
+  },
+  {
     "name": "Badhon Ai",
     "url": "https://www.badhon.online"
   },
@@ -1984,11 +1994,6 @@
     "tagline": "Software Engineer, Quant Developer"
   },
   {
-    "name": "Cid Kageno",
-    "url": "https://www.mritunjoy.online",
-    "tagline": "Full Stack Developer"
-  },
-  {
     "name": "Ciro Ciampaglia",
     "url": "https://cirociampaglia.it"
   },
@@ -2429,6 +2434,11 @@
     "tagline": "Software Engineer | Backend Engineering & Cloud"
   },
   {
+    "name": "Ditom Baroi Antu",
+    "url": "https://xtditom.github.io",
+    "tagline": "Web Developer | Open-Source Contributor"
+  },
+  {
     "name": "Divij Shrivastava",
     "url": "https://divij.tech"
   },
@@ -2469,6 +2479,11 @@
   {
     "name": "Dustin Doan",
     "url": "https://dustindoan-portfolio.vercel.app"
+  },
+  {
+    "name": "Dustin VanKrimpen",
+    "url": "https://dustinvk.com",
+    "tagline": "Full Stack Web Developer | Platform | Backend"
   },
   {
     "name": "Dylan Gil Amaro",
@@ -2913,6 +2928,11 @@
     "url": "https://gianlucagalota.dev"
   },
   {
+    "name": "Gii-DE",
+    "url": "https://g-dea.com",
+    "tagline": "Creative Engineer (AI & Web) | based in Europe"
+  },
+  {
     "name": "Gil Itzhaky Gilitz",
     "url": "https://gilitz.com"
   },
@@ -2964,6 +2984,11 @@
     "url": "https://gretamacri.com"
   },
   {
+    "name": "Guna Teja",
+    "url": "https://tejafolio.dev",
+    "tagline": "AI ML Student"
+  },
+  {
     "name": "Gunasree",
     "url": "https://gunasree-portfolio.vercel.app",
     "tagline": "AI Engineer | Technical Expertise"
@@ -3006,6 +3031,11 @@
   {
     "name": "Hamza Naseem",
     "url": "https://hamzanaseem.vercel.app"
+  },
+  {
+    "name": "Hangga Aji Sayekti",
+    "url": "https://hangga.web.id",
+    "tagline": "Software Engineer · Security Researcher · Tech Author"
   },
   {
     "name": "Hanif Yuli Abdillah",
@@ -3399,6 +3429,11 @@
     "tagline": "Repo"
   },
   {
+    "name": "Jason Flatford",
+    "url": "https://jasonflatford.com",
+    "tagline": "Product & Engineering Leader"
+  },
+  {
     "name": "Jatin Jadon",
     "url": "https://portfolio-jatin-two.vercel.app",
     "tagline": "Full Stack Developer"
@@ -3495,11 +3530,6 @@
   {
     "name": "Jens Van Wijhe",
     "url": "https://www.beterbekend.nl"
-  },
-  {
-    "name": "Jenul Ferdinand",
-    "url": "https://jenulferdinand.dev",
-    "tagline": "Software Engineer | Bcompsci 26' At Monash University"
   },
   {
     "name": "Jeremiah Haastrup",
@@ -4034,6 +4064,16 @@
     "tagline": "Software Developer"
   },
   {
+    "name": "Lalith Kumar",
+    "url": "https://lalith-d-portfolio.netlify.app",
+    "tagline": "AI Engineer | Data Scientist | Machine Learning Engineer"
+  },
+  {
+    "name": "Lalith",
+    "url": "https://portfolic.vercel.app/lalithdabilpuram01",
+    "tagline": "Data Scientist"
+  },
+  {
     "name": "Laercio Rios",
     "url": "https://laerciorios.com",
     "tagline": "Full Stack Developer | Software Engineer"
@@ -4250,6 +4290,11 @@
     "url": "http://mahdi.is-a.dev"
   },
   {
+    "name": "Mahin Hasan",
+    "url": "https://mahin527.vercel.app",
+    "tagline": "Shopify Expert | Full Stack Web Developer"
+  },
+  {
     "name": "Mahmoud Nabhan",
     "url": "https://mahmoudnabhan.com"
   },
@@ -4340,6 +4385,11 @@
     "name": "Manoj Hankare",
     "url": "https://manojhankare.in",
     "tagline": "Full Stack Developer | AI Engineer"
+  },
+  {
+    "name": "Manoj Kumar Mandal",
+    "url": "https://manojmandal.com",
+    "tagline": "Full Stack Engineer | AI Engineer | Generative AI | SaaS"
   },
   {
     "name": "Manoj Thilakarathna",
@@ -4874,6 +4924,11 @@
     "tagline": "AI/ML Engineer | Full Stack Developer"
   },
   {
+    "name": "Muhammad Taha Nawab",
+    "url": "https://taha-nawab-portfolio.vercel.app",
+    "tagline": "Full Stack Developer · AI/ML Engineer"
+  },
+  {
     "name": "Muhammad Tayyab",
     "url": "https://iamtayyab.com",
     "tagline": "Full Stack Software Engineer"
@@ -4887,6 +4942,10 @@
     "name": "Muhammad Ubaid Raza",
     "url": "https://mubaidr.js.org",
     "tagline": "Sr. Software Engineer | Full Stack Developer | Chrome Extension Expert"
+  },
+  {
+    "name": "Muhammed Ijlan",
+    "url": "https://ijlan.dev"
   },
   {
     "name": "Muhammet Fatih Di̇Nç",
@@ -5330,6 +5389,11 @@
     "tagline": "Senior Software Developer | React, TypeScript, Frontend Architecture"
   },
   {
+    "name": "Parth Kale",
+    "url": "https://parkky.vercel.app",
+    "tagline": "AI Engineer"
+  },
+  {
     "name": "Parth Kaul",
     "url": "https://parthkaul-bit.github.io/portfolio"
   },
@@ -5437,6 +5501,11 @@
   {
     "name": "Philipe Almeida",
     "url": "https://palmeida.netlify.app"
+  },
+  {
+    "name": "Philippe Fanaro",
+    "url": "https://aquarifolio.vercel.app",
+    "tagline": "Full Stack Developer"
   },
   {
     "name": "Phpxcoder",
@@ -6805,6 +6874,11 @@
     "url": "https://silasrodrigues.vercel.app"
   },
   {
+    "name": "Simon Aytes",
+    "url": "https://saytes.io",
+    "tagline": "Senior Data Scientist | AI/ML, Software Engineering"
+  },
+  {
     "name": "Simon Fereshetyan",
     "url": "https://fereshetyan.space",
     "tagline": "Software Engineer / DevOps"
@@ -6894,11 +6968,6 @@
   {
     "name": "Sourav Dutta",
     "url": "http://i-am-souravdutta.firebaseapp.com"
-  },
-  {
-    "name": "Sparsh Kamat",
-    "url": "http://sparshkamat.me",
-    "tagline": "Full Stack Web Developer"
   },
   {
     "name": "Sree Godavarthi",
@@ -7745,8 +7814,8 @@
     "tagline": "Full Stack AI Developer"
   },
   {
-    "name": "Yaksh Devani",
-    "url": "https://yakshdevani.framer.website",
+    "name": "Yaksh Bambhroliya",
+    "url": "https://yakshcore.vercel.app",
     "tagline": "Full Stack Developer"
   },
   {
@@ -7797,6 +7866,11 @@
   {
     "name": "Yassine Oularbi",
     "url": "https://yassineoularbi.github.io"
+  },
+  {
+    "name": "Yatharth Dixit",
+    "url": "https://yath.dev",
+    "tagline": "Backend/Full Stack Engineer | AI Products"
   },
   {
     "name": "Yeabsira Tarekegn",

--- a/feed.json
+++ b/feed.json
@@ -1761,11 +1761,6 @@
     "tagline": "Full Stack Developer"
   },
   {
-    "name": "Breakerino",
-    "url": "https://breakerino.me",
-    "tagline": "Full Stack Web Developer"
-  },
-  {
     "name": "Brendan Lentz",
     "url": "https://brendanlentz.com"
   },
@@ -3146,11 +3141,6 @@
   {
     "name": "Henry Lee",
     "url": "https://dragonwarrior.vercel.app"
-  },
-  {
-    "name": "Heny",
-    "url": "https://heny.dev",
-    "tagline": "Full Stack Developer | Mern | Next.Js"
   },
   {
     "name": "Herman Starikov",


### PR DESCRIPTION
## Summary
- Remove 5 portfolio entries with broken links found via ad/parking redirect bot (#3836) and link checker run #761
- Removed: Cid Kageno (DNS failure), Jenul Ferdinand (404), Sparsh Kamat (DNS failure), Breakerino (HTTP 522), Heny (connection failed)
- Portfolio count updated from 1793 to 1788

## Test plan
- [ ] Verify removed entries no longer appear in README.md
- [ ] Confirm alphabetical ordering is preserved
- [ ] Confirm portfolio count is accurate

Closes #3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)