### PR TITLE
Remove 6 broken portfolio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1812
+## Current Portfolio Count: 1806
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -97,7 +97,6 @@ This repo can serve as inspiration for your portfolio!
 - [Abhishek Singh](https://www.abhishekworks.com) [Full Stack Developer]
 - [Abinash Sharma](https://abinash-sharma.pages.dev) [Software Developer | MCA | Cloud | AI]
 - [Abraham Bankole](https://abrahambankole.dev)[Software Engineer | Full Stack Web Developer]
-- [Abu Bakar Butt](https://abu-bakar-portfolio-mauve.vercel.app)[ Full Stack Web Developer]
 - [Abu Suhaib](https://ceo.pronexus.in) [Leading Startup Founder]
 - [Abubakr Mufutau-Oseni](https://abubakrmo.com)
 - [Achyut Katiyar](https://www.achyutkatiyar.com) [Full Stack Developer| UI/UX Desginer]
@@ -833,7 +832,6 @@ Extension]
 - [Jay Bhavsar](https://jay.is-savvy.dev)
 - [Jay Gaha](https://jaygaha.com.np) [Full Stack Developer]
 - [Jay Keraliya](https://jaykeraliya.com)
-- [Jay Vegad](https://jayvegad.vercel.app)
 - [Jay](https://jay-65.netlify.app) [Frontend Developer]
 - [Jaya Vignesh](https://jayavignesh.dev) [Backend Developer]
 - [Jayant Goel](http://jayantgoel001.github.io)
@@ -943,7 +941,6 @@ Extension]
 - [Khizar Fareed](https://khizarfareed.netlify.app) [Engineer]
 - [Khokon](https://khokon.dev)
 - [Khulile Nzimande](https://khulilen.github.io/Portfolio-Website/) [Software Developer]
-- [Kidus Bewket](https://kidus.ca)
 - [Kiran Poudel](https://pkiran.com.np)
 - [Kishor Jeyachandran](https://kishorrj.vercel.app)
 - [Kishore](https://mkishore.is-a.dev)
@@ -1417,7 +1414,6 @@ Extension]
 - [Richard Porter](https://richardporter.dev) [Full Stack Developer | Laravel | Vue | React]
 - [Rick Hanlon](https://rickhanlonii.github.io)
 - [Ricky Serrano](https://rickyserrano.dev) [Help Desk Grunt | Next.js, React, SpringBoot, Full Stack]
-- [Ridoy Dey](https://iamridoydey.com) [Devops & Cloud Engineer | python, bash, go, Docker, CI/CD, Kubernetes, aws, azure, azure devops]
 - [Ridwan Ajanaku](https://olakunle.dev) [Frontend Software Engineer]
 - [Rifat Ishtiyak](https://rifat-ishtiyak.web.app)
 - [Rifqisakha](https://www.rifqisakha.my.id) [Frontend Developer, Designer, Ui/Ux]
@@ -1566,7 +1562,6 @@ Extension]
 - [Scott Spence](https://scottspence.com)
 - [Sebastian Cherny](https://sebascherny.github.io)
 - [Sebbie Chanzu](https://sebbie-chanzu.vercel.app) [Backend, DevOps And Machine Learning Engineer]
-- [Sebi](https://sebilune.dev) [Full Stack Developer]
 - [Serdar Salim](https://serdarsalim.com) [Automation Engineer]
 - [Sergei Chestakov](https://sergei.com)
 - [Sergio Sanchez](https://sdsanchezm.github.io) [.Net And Java Dev]
@@ -1673,7 +1668,6 @@ Extension]
 - [Sudev Thapa Magar](https://www.sudevmagar.tech)
 - [Suhail Roushan](https://suhailroushan.com)
 - [Sujal Bedre](https://sujal-bedre.vercel.app) [Ai/Ml Dev && Mern-Stack Dev]
-- [Sumeet Haldar](https://hsumeet.site)
 - [Sumeet](https://full-stack-liard-eight.vercel.app)[Software Developer]
 - [Sumonta Saha Mridul](https://sumonta056.github.io)
 - [Sunil Band](https://www.sunilband.com) [Frontend Engineer]

--- a/feed.json
+++ b/feed.json
@@ -338,10 +338,6 @@
     "url": "https://abrahambankole.dev"
   },
   {
-    "name": "Abu Bakar Butt",
-    "url": "https://abu-bakar-portfolio-mauve.vercel.app"
-  },
-  {
     "name": "Abu Suhaib",
     "url": "https://ceo.pronexus.in",
     "tagline": "Leading Startup Founder"
@@ -3514,10 +3510,6 @@
     "url": "https://jaykeraliya.com"
   },
   {
-    "name": "Jay Vegad",
-    "url": "https://jayvegad.vercel.app"
-  },
-  {
     "name": "Jay",
     "url": "https://jay-65.netlify.app",
     "tagline": "Frontend Developer"
@@ -3997,10 +3989,6 @@
     "name": "Khulile Nzimande",
     "url": "https://khulilen.github.io/Portfolio-Website/",
     "tagline": "Software Developer"
-  },
-  {
-    "name": "Kidus Bewket",
-    "url": "https://kidus.ca"
   },
   {
     "name": "Kiran Poudel",
@@ -6023,11 +6011,6 @@
     "tagline": "Help Desk Grunt | Next.js, React, SpringBoot, Full Stack"
   },
   {
-    "name": "Ridoy Dey",
-    "url": "https://iamridoydey.com",
-    "tagline": "Devops & Cloud Engineer | python, bash, go, Docker, CI/CD, Kubernetes, aws, azure, azure devops"
-  },
-  {
     "name": "Ridwan Ajanaku",
     "url": "https://olakunle.dev",
     "tagline": "Frontend Software Engineer"
@@ -6672,11 +6655,6 @@
     "tagline": "Backend, DevOps And Machine Learning Engineer"
   },
   {
-    "name": "Sebi",
-    "url": "https://sebilune.dev",
-    "tagline": "Full Stack Developer"
-  },
-  {
     "name": "Serdar Salim",
     "url": "https://serdarsalim.com",
     "tagline": "Automation Engineer"
@@ -7152,10 +7130,6 @@
     "name": "Sujal Bedre",
     "url": "https://sujal-bedre.vercel.app",
     "tagline": "Ai/Ml Dev && Mern-Stack Dev"
-  },
-  {
-    "name": "Sumeet Haldar",
-    "url": "https://hsumeet.site"
   },
   {
     "name": "Sumeet",


### PR DESCRIPTION
## Summary

- Removes 6 portfolio entries flagged as broken by the lychee link checker (workflow run 28297953076)
- 2 returned HTTP 404, 1 had a TLS error, 3 failed to connect

| URL | Error |
|---|---|
| `https://abu-bakar-portfolio-mauve.vercel.app/` | 404 Not Found |
| `https://iamridoydey.com/` | 404 Not Found |
| `https://hsumeet.site/` | TLS fatal alert (InternalError) |
| `https://jayvegad.vercel.app/` | Connection failed |
| `https://kidus.ca/` | Connection failed |
| `https://sebilune.dev/` | Connection failed |

## Test plan

- [ ] Verify removed entries no longer appear in README.md
- [ ] Re-run link checker to confirm no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)