### PR TITLE
Add site Stimmie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1662,6 +1662,7 @@ Extension]
 - [Stephanie Lin](https://lin-stephanie.github.io)
 - [Stuart Blackler](https://codewithstu.tv) [Principal Software Engineer | AWS | .NET]
 - [Stéphane Chan Hiou Kong](https://www.chan-stephane.me)
+- [Stimmie](https://stimmie.dev) [Software Engineer | Next.js]
 - [Subhajit Kar](https://next-portfolio-tan-ten.vercel.app) [Full Stack Developer]
 - [Subhan Nadeem](https://subhan-dev-portfolio.vercel.app)
 - [Subhasish Das](https://subhasish-portfolio.vercel.app)


### PR DESCRIPTION
## Summary

Adds [stimmie.dev](https://stimmie.dev) — a Next.js software-engineer portfolio with a bento layout, talks/projects pages, and an open-source repo.

## Checklist

- [x] Portfolio link loads correctly in a browser (no parking page / error)
- [x] Entry added in strict alphabetical order (after Stéphane Chan Hiou Kong, before Subhajit Kar)
- [x] Did **not** edit `feed.json`

**Entry:** `- [Stimmie](https://stimmie.dev) [Software Engineer | Next.js]`