### PR TITLE
chore: remove dead/parked portfolio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1836
+## Current Portfolio Count: 1831
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -38,7 +38,6 @@ This repo can serve as inspiration for your portfolio!
 - [Aaleksa Janjic](https://akkila.dev) [Full Stack Developer]
 - [Aanand Madhav](https://aanandmadhav.com) [Senior PM | UX]
 - [Aarab Nishchal](https://aarab.vercel.app) [Engineering Student | Full Stack Developer]
-- [Aarav Gupta](https://aarus2709.me)
 - [Aaron Dunphy](https://aarondunphy.com)
 - [Aaryanna Simonelli](https://ashleighsimonelli.co.uk)
 - [Aashay Wase](https://aashay-dev-ed.develop.my.site.com/AashayWase/s) [Salesforce Developer]
@@ -579,7 +578,6 @@ Extension]
 - [Dina Taklit](https://dinataklit.github.io/DinaTaklitPortfolio)
 - [Dinesh Barri](https://dineshbarri-portfolio.vercel.app) [Data Sceintist | Ai Automation Engineer]
 - [Dineshreddy Paidi](https://dineshreddypaidi.vercel.app)
-- [Dino Gomez](https://dinogomez.vercel.app)
 - [Dino Kupinic](https://dino-kupinic.dev) [Software Engineer]
 - [Dinokage](https://dinokage.in)
 - [Dipak Mourya](https://dipakdev.in) [Full Stack Developer]
@@ -803,7 +801,6 @@ Extension]
 - [Indrayudh Dhara](https://my-portfolio-ba1h.vercel.app) [Full Stack Developer]
 - [Ingus Jansons](https://ingus.co.uk)
 - [Ioannis Jone-Magalhaes](https://ioannisjonemagalhaes.com) [Software Engineer | Cloud & IoT]
-- [Irfan.Dev](https://irfan-devs.vercel.app) [Frontend Developer]
 - [Isabella Riquetti](https://isabella-riquetti.netlify.app)
 - [Ishaan Ray](https://galaxir.vercel.app) [Full Stack Developer | AI Engineer]
 - [Ishaan Sheikh](https://frikishaan.com)
@@ -977,7 +974,6 @@ Extension]
 - [Kuppili Nikhilesh Raju](https://nikhileshraju.me) [AI/ML Engineer]
 - [Kushan Devarajegowda](https://ikushdev.github.io) [Software Developer | Software Engineer | Sde | Swe]
 - [Kushwinth Kumar](https://iamkushwidev.vercel.app) [Software Developer | Frontend Engineer | Mern Stack Developer]
-- [Kwameh Dhegbo](https://kwamehdhegbo.com) [Full Stack Developer | Software Developer | Software Engineer | Student]
 - [Kyle Smith](https://yskkyle.com)
 - [Kyson](https://kyson.dev)
 - [kenTom](https://kentom.co.ke) [Software Developer]
@@ -1828,7 +1824,6 @@ Extension]
 - [Vijay Verma](https://vjy.me)
 - [Vikas Chauhan](https://vikaschauhan.vercel.app)
 - [Vikas Ukani](https://vikas-ukani.github.io)
-- [Vinay Katikireddy](https://vinaykatikireddy.is-a.dev) [Cybersecurity, Full Stack Developer]
 - [Vinay Kumar](https://n4ryn.com) [Full Stack Developer]
 - [Vinay Somawat](https://vinaysomawat.github.io)
 - [Vineet Saraf](https://coastalvinny.dev)

--- a/feed.json
+++ b/feed.json
@@ -68,10 +68,6 @@
     "tagline": "Engineering Student | Full Stack Developer"
   },
   {
-    "name": "Aarav Gupta",
-    "url": "https://aarus2709.me"
-  },
-  {
     "name": "Aaron Dunphy",
     "url": "https://aarondunphy.com"
   },
@@ -2476,10 +2472,6 @@
     "url": "https://dineshreddypaidi.vercel.app"
   },
   {
-    "name": "Dino Gomez",
-    "url": "https://dinogomez.vercel.app"
-  },
-  {
     "name": "Dino Kupinic",
     "url": "https://dino-kupinic.dev",
     "tagline": "Software Engineer"
@@ -3402,11 +3394,6 @@
     "tagline": "Software Engineer | Cloud & IoT"
   },
   {
-    "name": "Irfan.Dev",
-    "url": "https://irfan-devs.vercel.app",
-    "tagline": "Frontend Developer"
-  },
-  {
     "name": "Isabella Riquetti",
     "url": "https://isabella-riquetti.netlify.app"
   },
@@ -4160,11 +4147,6 @@
     "name": "Kushwinth Kumar",
     "url": "https://iamkushwidev.vercel.app",
     "tagline": "Software Developer | Frontend Engineer | Mern Stack Developer"
-  },
-  {
-    "name": "Kwameh Dhegbo",
-    "url": "https://kwamehdhegbo.com",
-    "tagline": "Full Stack Developer | Software Developer | Software Engineer | Student"
   },
   {
     "name": "Kyle Smith",
@@ -7812,11 +7794,6 @@
   {
     "name": "Vikas Ukani",
     "url": "https://vikas-ukani.github.io"
-  },
-  {
-    "name": "Vinay Katikireddy",
-    "url": "https://vinaykatikireddy.is-a.dev",
-    "tagline": "Cybersecurity, Full Stack Developer"
   },
   {
     "name": "Vinay Kumar",


### PR DESCRIPTION
Closes #3898

Removes the 5 entries flagged by the automated ad/parking redirect report:

| Name | URL | Reason |
|---|---|---|
| Aarav Gupta | https://aarus2709.me | DNS resolution failed |
| Dino Gomez | https://dinogomez.vercel.app | HTTP 404 |
| Irfan.Dev | https://irfan-devs.vercel.app | HTTP 404 |
| Kwameh Dhegbo | https://kwamehdhegbo.com | DNS resolution failed |
| Vinay Katikireddy | https://vinaykatikireddy.is-a.dev | HTTP 404 |

All 5 independently re-verified as dead before removal. `feed.json` and portfolio count regenerated automatically by the pre-commit hook.

## Test plan
- [x] Confirmed each URL fails (curl HTTP status / DNS lookup)
- [x] Confirmed no other stray references to these names remain in README.md