### PR TITLE
Add site Aref Shalchi

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ This repo can serve as inspiration for your portfolio!
 - [Arbaz Ansari](https://arbazansari.dev) [Full Stack Software Engineer | Exploring GenAi & Systems Design]
 - [Arctan2](https://arctan2.github.io) [Full Stack | Frontend Heavy | Software Generalist]
 - [Areeb Ahmed](https://areebahmed-portfolio.netlify.app)
+- [Aref Shalchi](https://arefshalchi.com/) [iOS Developer | Mobile Developer]
 - [Arhaan Siddiquee](https://arhaan-dev.vercel.app) [Full Stack Developer]
 - [Ariel Andrade](https://sudoariel.github.io)
 - [Aries Chang](https://ariesjchang.com) [Software Engineer]


### PR DESCRIPTION
## What changed

- Added Aref Shalchi's portfolio in alphabetical order under the A section.
- Included the iOS Developer and Mobile Developer roles.

## Why

This adds https://arefshalchi.com/ to the developer portfolio collection.

## Validation

- Confirmed the portfolio URL responds successfully.
- Confirmed the entry is in alphabetical order.
- Confirmed only `README.md` changed.
