### PR TITLE
Add Hussam Barqawi portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ Extension]
 - [Hugo Folloni](https://hugofolloni.com)
 - [Humanshu Jaglan](https://humanshu-jaglan.vercel.app)
 - [Hungry Bear Studio](https://www.hungrybearstudios.com)
+- [Hussam Barqawi](https://portfolio-kappa-mauve-pfdsqi3ae7.vercel.app/) [AI Engineer | LLM Engineer | AI Agent Developer]
 - [Hussein Sarea](https://ho011.vercel.app)
 
 ## I


### PR DESCRIPTION
## Summary
- Adds Hussam Barqawi's AI Engineer portfolio to the list in alphabetical order.

## Test plan
- [x] Portfolio link loads correctly: https://portfolio-kappa-mauve-pfdsqi3ae7.vercel.app/
- [x] Entry added alphabetically under **H**
- [x] Did not edit `feed.json` (auto-generated)