### PR TITLE
Add Seif Osman's portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1623,6 +1623,7 @@ Extension]
 - [Scott Spence](https://scottspence.com)
 - [Sebastian Cherny](https://sebascherny.github.io)
 - [Sebbie Chanzu](https://sebbie-chanzu.vercel.app) [Backend, DevOps And Machine Learning Engineer]
+- [Seif Osman](https://seifosman.com) [IT Store Technology Engineer | Full-Stack & Security]
 - [Serdar Salim](https://serdarsalim.com) [Automation Engineer]
 - [Sergei Chestakov](https://sergei.com)
 - [Sergio Sanchez](https://sdsanchezm.github.io) [.Net And Java Dev]


### PR DESCRIPTION
Adding my portfolio: [seifosman.com](https://seifosman.com) — inserted in the **S** section in alphabetical order (between Sebbie Chanzu and Serdar Salim).

- [x] I have opened my portfolio link in a browser and it loads correctly — it does **not** redirect to a domain parking/sale page or return an error.
- [x] My entry is added in **strict alphabetical order** by first name.
- [x] I have **not** edited `feed.json`.