### PR TITLE
Add Marco Bellingeri portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,6 +1115,7 @@ This repo can serve as inspiration for your portfolio!
 - [Marc Backes](http://marc.dev)
 - [Marciano Mavungo](https://marcmav.dev) [Frontend Software Engineer | vanillaJS | TailwindCSS]
 - [Marco Baldini](https://marcobaldini.pages.dev)
+- [Marco Bellingeri](https://marcobellingeri.dev) [Cloud Platform & AI Security Engineer | RAG & agentic AI | OWASP LLM Top 10]
 - [Marcos Moura](https://marcos-moura97.github.io)
 - [Marcus Sánchez](https://marcuss.pro) [Staff Backend Engineer | Distributed Systems | AI]
 - [Marin Takanov](https://www.takanov.com) [Senior Software Engineer]


### PR DESCRIPTION
Adds my portfolio to the list.

```markdown
- [Marco Bellingeri](https://marcobellingeri.dev) [Cloud Platform & AI Security Engineer | RAG & agentic AI | OWASP LLM Top 10]
```

Inserted in alphabetical order, between **Marco Baldini** and **Marcos Moura**.

### Checklist

- [x] I have opened my portfolio link in a browser and it loads correctly — it does not redirect to a domain parking/sale page or return an error (HTTP 200; the root picks the language, `/it/` or `/en/`, and the site is bilingual).
- [x] I have not edited `feed.json`.
- [x] My entry is added in strict alphabetical order by first name.
- [x] Branch named `add/marco-bellingeri`, single-line change to `README.md`.

### About the site

Built with Astro on Cloudflare Workers, bilingual IT/EN, and built around one idea: **show rather than claim**. The Security section reads the HTTP security headers back out of the response the browser just received, the terminal answers questions against a RAG index of the site's own writing, and the monthly issue is produced by a pipeline with human gates. Source is public: [github.com/MK023/marcobellingeri.dev](https://github.com/MK023/marcobellingeri.dev).

Thanks for maintaining this list.