### PR TITLE
Add site Saksham Sirohi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,6 +1612,7 @@ This repo can serve as inspiration for your portfolio!
 - [Sakib Mansuri](https://sakib-m.me) [Software engineer/AI developer]
 - [Sakib Rahman](https://rsakib.com) [Software Engineer]
 - [Saksham Agarwal](https://skshamagarwal.github.io)
+- [Saksham Sirohi](https://saksham-sirohi.github.io) [Software Engineer | Open Source | Full-Stack]
 - [Sakshi Hanwat](https://sakshi-portfolio-eta-swart.vercel.app) [Java Full Stack Developer]
 - [Sakshi Jaiswal](https://sakshi.is-cool.dev) [Full Stack Developer | Next.Js | Ui/Ux]
 - [Sam Foreman](https://samforeman.me) [Computational Scientist]


### PR DESCRIPTION
## Summary
- Adds [Saksham Sirohi](https://saksham-sirohi.github.io) to the developer portfolios list (alphabetical, after Saksham Agarwal).
- Live site: https://saksham-sirohi.github.io
- Source: https://github.com/Saksham-Sirohi/Saksham-Sirohi.github.io

## Checklist
- [x] Portfolio link loads correctly
- [x] Entry is in strict alphabetical order by first name
- [x] Did not edit `feed.json`