### PR TITLE
Remove dead contributor links flagged in ad/parking report

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1944
+## Current Portfolio Count: 1939
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -468,7 +468,6 @@ This repo can serve as inspiration for your portfolio!
 ## C
 
 - [Cade Kynaston](https://cade.codes)
-- [Caiovisuals](https://www.caiovisuals.com) [Front-End Developer]
 - [Calzye](https://calzye.com) [AI-Powered Calculator Developer]
 - [Camel Djoulako](https://cameldjoulako.com) [Software Architect | Java, Spring Boot, Angular & Cloud/DevOps]
 - [Camil Bradea](https://bradeac.dev) [Senior Full Stack Engineer | TypeScript, React, Laravel, Docker, AWS]
@@ -573,7 +572,6 @@ This repo can serve as inspiration for your portfolio!
 - [Deepak Singh](https://deepaksingh.vercel.app)
 - [Delba](https://delba.dev)
 - [Delvin Khor](https://delvin.portfolio-me.bio)
-- [Delwer Hossain](https://delwer.live)
 - [Demon142](https://demon142.net)
 - [Denil Dominic](https://portfolio.denil-dominic.com)
 - [Denis Borovets](https://borove4ik.vercel.app) [Frontend Developer]
@@ -1180,7 +1178,6 @@ This repo can serve as inspiration for your portfolio!
 - [Mejed Alkoutaini](https://majd-portfolio.framer.website) [Software Engineer]
 - [Melih Arık](https://meliharik.dev) [Software Engineer | Mobile Developer]
 - [Melvin Biju](https://melvinbiju.vercel.app) [Full Stack Dev | Graphic Designer]
-- [Melvin Jones Repol](https://mrepol742.github.io)
 - [Melvin Prince](https://melvinprince.io)
 - [Melvyn Malherbe](https://melvynx.com)
 - [Mertcan Kose](https://mertcankose.vercel.app)
@@ -1526,7 +1523,6 @@ This repo can serve as inspiration for your portfolio!
 - [Rishabh Chaturvedi](https://rishabhchaturvedi.dev) [Lead Engineer | AI Architect & Backend Systems]
 - [Rishav Kumar Singh](https://rishavkumar-portfolio.vercel.app) [Software Engineer | Full Stack Developer]
 - [Rishav](https://v0idrsh.vercel.app)
-- [Rishhi Duetheesh](https://notesc.netlify.app) [Frontend Developer]
 - [Ritesh Bucha](https://bucharitesh.in) [Full Stack Developer]
 - [Rituparna Warwatkar](https://rituparnawarwatkar.com) [Sde@Aws Ec2, Berlin]
 - [Rizan Bhandari](https://acchyut.com.np) [Researcher & Full Stack Developer]
@@ -1612,7 +1608,7 @@ This repo can serve as inspiration for your portfolio!
 - [Sakib Mansuri](https://sakib-m.me) [Software engineer/AI developer]
 - [Sakib Rahman](https://rsakib.com) [Software Engineer]
 - [Saksham Agarwal](https://skshamagarwal.github.io)
-- [Saksham Sirohi](https://saksham-sirohi.github.io) [Software Engineer | Open Source | Full-Stack]
+- [Saksham Sirohi](https://saksham-sirohi.github.io) [Software Engineer | Open Source | Full Stack]
 - [Sakshi Hanwat](https://sakshi-portfolio-eta-swart.vercel.app) [Java Full Stack Developer]
 - [Sakshi Jaiswal](https://sakshi.is-cool.dev) [Full Stack Developer | Next.Js | Ui/Ux]
 - [Sam Foreman](https://samforeman.me) [Computational Scientist]
@@ -1620,7 +1616,6 @@ This repo can serve as inspiration for your portfolio!
 - [Samad Talukder](https://samadtalukder.com) [Full Stack & Mobile Developer | Exploring GenAi & Innovation Enthusiast]
 - [Samarth Batra](https://batrasamarth.com) [Software Developer]
 - [Samarth Kadam](https://samarthkadam.vercel.app)
-- [Samarth Kosta](https://xamarth.pp.ua)
 - [Sambhu Babu](https://sambhusbabu.com) [Frappe & ERPNext Developer]
 - [Sameer Agarwal](https://www.elite-lord.com) [Computer Science Student | Software Intern]
 - [Sameer](https://sameer27.netlify.app)
@@ -1959,7 +1954,6 @@ This repo can serve as inspiration for your portfolio!
 - [Vito Sartori](https://vito.io)
 - [Vitor Forbrig](https://forbrig.github.io)
 - [Vivek Choudhary](https://vivekportfoliopersonal.vercel.app) [Full Stack Engineer | AI Engineer]
-- [Vivek Chudasama](https://vivekchudasama-2004.github.io/portfolio)
 - [Vivek Ghodadra](https://vivek-ghodadra.web.app) [React Native, ReactJs, NodeJs Developer]
 - [Vivek Jaiswal](https://www.vivekjaiswal.me) [Software Archutect | Ai/Ml Expert]
 - [Vivek Patel Ubuntu](http://vivek9patel.github.io)

--- a/feed.json
+++ b/feed.json
@@ -2019,11 +2019,6 @@
     "url": "https://cade.codes"
   },
   {
-    "name": "Caiovisuals",
-    "url": "https://www.caiovisuals.com",
-    "tagline": "Front-End Developer"
-  },
-  {
     "name": "Calzye",
     "url": "https://calzye.com",
     "tagline": "AI-Powered Calculator Developer"
@@ -2467,10 +2462,6 @@
   {
     "name": "Delvin Khor",
     "url": "https://delvin.portfolio-me.bio"
-  },
-  {
-    "name": "Delwer Hossain",
-    "url": "https://delwer.live"
   },
   {
     "name": "Demon142",
@@ -5089,10 +5080,6 @@
     "tagline": "Full Stack Dev | Graphic Designer"
   },
   {
-    "name": "Melvin Jones Repol",
-    "url": "https://mrepol742.github.io"
-  },
-  {
     "name": "Melvin Prince",
     "url": "https://melvinprince.io"
   },
@@ -6585,11 +6572,6 @@
     "url": "https://v0idrsh.vercel.app"
   },
   {
-    "name": "Rishhi Duetheesh",
-    "url": "https://notesc.netlify.app",
-    "tagline": "Frontend Developer"
-  },
-  {
     "name": "Ritesh Bucha",
     "url": "https://bucharitesh.in",
     "tagline": "Full Stack Developer"
@@ -6960,6 +6942,11 @@
     "url": "https://skshamagarwal.github.io"
   },
   {
+    "name": "Saksham Sirohi",
+    "url": "https://saksham-sirohi.github.io",
+    "tagline": "Software Engineer | Open Source | Full Stack"
+  },
+  {
     "name": "Sakshi Hanwat",
     "url": "https://sakshi-portfolio-eta-swart.vercel.app",
     "tagline": "Java Full Stack Developer"
@@ -6992,10 +6979,6 @@
   {
     "name": "Samarth Kadam",
     "url": "https://samarthkadam.vercel.app"
-  },
-  {
-    "name": "Samarth Kosta",
-    "url": "https://xamarth.pp.ua"
   },
   {
     "name": "Sambhu Babu",
@@ -8483,10 +8466,6 @@
     "name": "Vivek Choudhary",
     "url": "https://vivekportfoliopersonal.vercel.app",
     "tagline": "Full Stack Engineer | AI Engineer"
-  },
-  {
-    "name": "Vivek Chudasama",
-    "url": "https://vivekchudasama-2004.github.io/portfolio"
   },
   {
     "name": "Vivek Ghodadra",


### PR DESCRIPTION
## Summary
- Removes 6 contributor entries flagged in #4097 as pointing to dead or ad/parking pages: Caiovisuals, Delwer Hossain, Melvin Jones Repol, Rishhi Duetheesh, Samarth Kosta, and Vivek Chudasama.
- Regenerates `feed.json` and the portfolio count via the repo's standard scripts (`src/alphabetical.py`, `src/generate_feed.py`), which also picked up a pending README→feed.json sync fix for Saksham Sirohi.

Fixes #4097

## Test plan
- [x] `python3 run_tests.py` — same single pre-existing failure (`test_strip_aaa_prefix_token`) present on `master` before this change; unrelated to this fix.
- [x] Verified all 6 flagged URLs removed from both `README.md` and `feed.json`.