### PR TITLE
Reduce false-positive timeout noise in link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,4 +22,28 @@ jobs:
 
       - name: Write broken links to Job Summary
         if: steps.lychee.outputs.exit_code != 0
-        run: cat ./lychee/out.md >> $GITHUB_STEP_SUMMARY
+        run: |
+          OUT=./lychee/out.md
+          [ -f "$OUT" ] || exit 0
+
+          # Timeouts are frequently false positives (e.g. hosts rate-limiting or
+          # silently dropping requests from CI datacenter IPs) rather than real
+          # dead links, so they're reported separately from actionable errors
+          # instead of drowning them out. See git history of this file/.lycherc.toml.
+          ACTIONABLE=$(grep '^\* \[' "$OUT" | grep -v '^\* \[TIMEOUT\]' || true)
+          TIMEOUTS=$(grep '^\* \[TIMEOUT\]' "$OUT" || true)
+
+          if [ -n "$ACTIONABLE" ]; then
+            echo "## 🚫 Broken links (action needed)" >> "$GITHUB_STEP_SUMMARY"
+            echo "$ACTIONABLE" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -n "$TIMEOUTS" ]; then
+            COUNT=$(echo "$TIMEOUTS" | wc -l | tr -d ' ')
+            echo "<details><summary>⏳ $COUNT timeout(s) — often false positives from CI network/rate limiting, verify manually before removing</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$TIMEOUTS" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.lycherc.toml
+++ b/.lycherc.toml
@@ -36,8 +36,10 @@ cache = true
 # These are handled by the .lycheeignore file
 
 # HTTP method to use for checking links
-# Using 'head' is faster and gentler on servers, falls back to 'get' if head fails
-method = "head"
+# GET instead of HEAD: several hosts (e.g. Netlify/Vercel edge networks) silently
+# hang on HEAD requests from datacenter IPs instead of responding, which shows up
+# as a false-positive timeout. GET is lychee's own upstream default for this reason.
+method = "get"
 
 # Prefer HTTPS over HTTP when both are available
 scheme = ["https", "http"]


### PR DESCRIPTION
## Summary
- Weekly link-checker run [31900130265](https://github.com/emmabostian/developer-portfolios/actions/runs/31900130265) reported 26 timeouts + 9 errors, but the 6 real broken links (already fixed in #4098) were indistinguishable from the timeouts in the Job Summary. I manually re-checked all 26 timed-out URLs directly and every one is live — timeouts are CI-network/rate-limiting artifacts, not dead links.
- `.lycherc.toml` previously relied on `timeout_ok = true` to treat timeouts as non-fatal, but that field was dropped by lychee (removed in 84853aaa when it started causing config parse failures) — there's no native replacement. This restores the distinction at the workflow level instead: the Job Summary now splits into an actionable **🚫 Broken links** section (real errors: 404/DNS/connection failures) and a collapsed **⏳ Timeouts** section labeled as likely false positives.
- Also switched lychee's request `method` from `head` to `get` (lychee's own upstream default). Many of the timed-out hosts are on Netlify/Vercel edge networks, which appear to silently drop HEAD requests from datacenter IPs rather than responding — GET is the more standard, less scanner-like request pattern.

## Test plan
- [x] Extracted and dry-ran the new summary-filtering shell logic against a sample `lychee/out.md` modeled on the real run's output — confirmed actionable errors and timeouts are correctly separated into their respective sections.
- [x] Validated workflow YAML and `.lycherc.toml` TOML both parse correctly.
- [x] `python3 run_tests.py` — same single pre-existing failure (`test_strip_aaa_prefix_token`), unrelated to this change.
- [x] This is a non-blocking, informational-only workflow (`continue-on-error: true`), so no behavior change to CI gating — only what gets surfaced in the summary.