### PR TITLE
Remove dead contributor links surfaced by link-checker run 31974195212

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1939
+## Current Portfolio Count: 1936
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -469,7 +469,6 @@ This repo can serve as inspiration for your portfolio!
 
 - [Cade Kynaston](https://cade.codes)
 - [Calzye](https://calzye.com) [AI-Powered Calculator Developer]
-- [Camel Djoulako](https://cameldjoulako.com) [Software Architect | Java, Spring Boot, Angular & Cloud/DevOps]
 - [Camil Bradea](https://bradeac.dev) [Senior Full Stack Engineer | TypeScript, React, Laravel, Docker, AWS]
 - [Capt Michael](https://captmichael.dev) [Mern Full Stack Developer]
 - [Carlos Dubón](https://carlosdubon.dev)
@@ -802,7 +801,6 @@ This repo can serve as inspiration for your portfolio!
 - [Hassan Ahmed](https://www.hassanahmed.net)
 - [Hassan Ali](https://hassan-ali-portfolio-nine.vercel.app) [Full Stack AI Developer | DevOps Engineer]
 - [Hassan Rj](https://hassanrj.vercel.app) [Hassan RJ Full Stack Next.js Developer]
-- [Hassan Tech](https://hassanx.tech) [Web Developer]
 - [Hemang Yadav](https://zemerik.vercel.app) [Passionate Developer]
 - [Hemanth Chakravarthy Kancharla](https://hemanth-chakravarthy.netlify.app) [Engineering Student | Full Stack Developer]
 - [Henry Lee](https://dragonwarrior.vercel.app)
@@ -1133,7 +1131,6 @@ This repo can serve as inspiration for your portfolio!
 - [Mariya Jebastin](https://mariyajebastin.netlify.app) [Full Stack Developer]
 - [Mark Ernst](https://cyntax.dev) [Freelance Senior Full Stack Software Engineer at Cyntax | .NET/PHP/TS]
 - [Marko Denic](https://markodenic.com)
-- [Markus Polzer](https://www.rapidtech1898.com)
 - [Marouane Rassili](https://mrassili.com)
 - [Martin Barker](https://martinbarker.me)
 - [Martin Lefebvre](https://martinlefebvre.com) [Senior Full Stack Developer | Tech Lead]

--- a/feed.json
+++ b/feed.json
@@ -2024,11 +2024,6 @@
     "tagline": "AI-Powered Calculator Developer"
   },
   {
-    "name": "Camel Djoulako",
-    "url": "https://cameldjoulako.com",
-    "tagline": "Software Architect | Java, Spring Boot, Angular & Cloud/DevOps"
-  },
-  {
     "name": "Camil Bradea",
     "url": "https://bradeac.dev",
     "tagline": "Senior Full Stack Engineer | TypeScript, React, Laravel, Docker, AWS"
@@ -3432,11 +3427,6 @@
     "name": "Hassan Rj",
     "url": "https://hassanrj.vercel.app",
     "tagline": "Hassan RJ Full Stack Next.js Developer"
-  },
-  {
-    "name": "Hassan Tech",
-    "url": "https://hassanx.tech",
-    "tagline": "Web Developer"
   },
   {
     "name": "Hemang Yadav",
@@ -4873,10 +4863,6 @@
   {
     "name": "Marko Denic",
     "url": "https://markodenic.com"
-  },
-  {
-    "name": "Markus Polzer",
-    "url": "https://www.rapidtech1898.com"
   },
   {
     "name": "Marouane Rassili",


### PR DESCRIPTION
## Summary
- Removes 3 contributor entries flagged as errors (not timeouts) in [run 31974195212](https://github.com/emmabostian/developer-portfolios/actions/runs/31974195212), the first run after #4099's timeout-noise fix: Camel Djoulako, Hassan Tech, Markus Polzer.
- A 4th flagged entry (`beno-portofolio-v2.onrender.com`, 503) was left alone — it returned `200` on recheck, consistent with a Render free-tier cold start rather than a dead link.

Each of the 3 removed was independently re-verified by hand (not just trusting the single CI run) before removal:
- **Camel Djoulako** (`cameldjoulako.com`) — DNS resolves, but every connection attempt timed out across 3 retries over several minutes.
- **Hassan Tech** (`hassanx.tech`) — resolves to `127.0.0.1` (loopback), a strong signal of an expired/misconfigured domain. Also failed the same way (connection refused) in the prior day's scheduled run, so it's a recurring failure, not a blip.
- **Markus Polzer** (`www.rapidtech1898.com`) — Cloudflare-fronted, but Cloudflare itself returns `522` (cannot reach origin) consistently across repeated checks.

## Test plan
- [x] `python3 run_tests.py` — same single pre-existing failure (`test_strip_aaa_prefix_token`) present on `master`, unrelated to this change.
- [x] Verified all 3 URLs removed from both `README.md` and `feed.json`.