### PR TITLE
Create an issue from actionable link-checker errors

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -37,6 +37,18 @@ jobs:
             echo "## 🚫 Broken links (action needed)" >> "$GITHUB_STEP_SUMMARY"
             echo "$ACTIONABLE" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
+
+            # Also written as its own file so the issue-creation step below can
+            # report just the actionable errors, without the timeout noise.
+            {
+              echo "## Broken Links Report"
+              echo ""
+              echo "Lychee found link(s) rejected with a real error. Timeouts are"
+              echo "excluded here since they're frequently false positives from CI"
+              echo "network/rate limiting — see this run's Job Summary for those."
+              echo ""
+              echo "$ACTIONABLE"
+            } > ./lychee/actionable.md
           fi
 
           if [ -n "$TIMEOUTS" ]; then
@@ -47,3 +59,11 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "</details>" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v6
+        with:
+          title: "[Bot] Broken Links Report"
+          content-filepath: ./lychee/actionable.md
+          labels: report

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1936
+## Current Portfolio Count: 1937
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)

--- a/feed.json
+++ b/feed.json
@@ -2533,6 +2533,11 @@
     "url": "https://dhavalcode.com"
   },
   {
+    "name": "Dheeraj Akula",
+    "url": "https://dheerajakula.dev",
+    "tagline": "Software Engineer | Agent Harnesses & Developer Tools"
+  },
+  {
     "name": "Dheeraj Gupta",
     "url": "https://dheerajgupta.netlify.app/#"
   },


### PR DESCRIPTION
## Summary
- Restores issue creation for the weekly `link-checker` workflow, mirroring `parking-redirect-checker.yml`'s pattern (`peter-evans/create-issue-from-file`, `labels: report`).
- Issue creation was removed from this workflow in 255c6889 to avoid failures when Issues was disabled — but `parking-redirect-checker.yml` already proves Issues is enabled on this repo (see e.g. #4097) and creates issues successfully, so that blocker no longer applies.
- Only the **actionable** (non-timeout) errors are included in the issue — timeouts stay in the Job Summary only, per #4099's fix, since they're frequently CI-network/rate-limiting false positives rather than real broken links.
- If a run has nothing actionable (only timeouts, or fully clean), `./lychee/actionable.md` is never written and `create-issue-from-file` silently no-ops — same behavior `check_parking_redirects.py` already relies on for its own issue step.

## Test plan
- [x] Dry-ran the updated shell logic against a sample `lychee/out.md` (mix of timeout + real errors) — confirmed `actionable.md` contains only the non-timeout entries with a clear header, and the Job Summary still gets both sections.
- [x] Dry-ran the timeout-only case — confirmed `actionable.md` is never created.
- [x] Validated the workflow YAML parses correctly.
- [x] `python3 run_tests.py` — same single pre-existing failure (`test_strip_aaa_prefix_token`), unrelated to this change.