### PR TITLE
Remove dead portfolio links flagged in issue #4124

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1937
+## Current Portfolio Count: 1946
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -95,7 +95,6 @@ This repo can serve as inspiration for your portfolio!
 - [Abhishek Bhardwaj](https://www.imabhishek.site)
 - [Abhishek Ganvir](https://abhishekganvir.vercel.app) [Full Stack Developer]
 - [Abhishek Ghimire](https://www.abhishekg.com.np) [Software Engineer]
-- [Abhishek Kandel](https://abhishekkandel.com.np)
 - [Abhishek Panchal](https://skillstackpanchal.vercel.app)
 - [Abhishek Panthee](https://abhishekpanthee.com.np)
 - [Abhishek Sah](https://www.abhisheksah.dev) [Software Engineer]
@@ -462,10 +461,10 @@ This repo can serve as inspiration for your portfolio!
 - [Brijesh Patel](https://brijesh.work)
 - [Brittany Chiang](https://brittanychiang.com)
 - [Bruno Simon](https://bruno-simon.com)[Three.js Developer]
-- [Burhanaddin Mirsadizada](https://burhanaddinzm.github.io/)
 - [Bryan Elliott](https://elliottprogrammer.com) [Senior/Staff Frontend Leaning Full Stack Software Engineer]
 - [Bryan Smith](https://multikitty.onrender.com)
   Extension]
+- [Burhanaddin Mirsadizada](https://burhanaddinzm.github.io)
 
 ## C
 
@@ -492,7 +491,7 @@ This repo can serve as inspiration for your portfolio!
 - [Charles Degraeuwe](https://charlesdegraeuwe.com) [Student | Full Stack Engineer]
 - [Charles Ouimet](https://ouimet.info) [Backend Developer]
 - [Charles Pustejovsky Iii](https://cpustejovsky.com)
-- [Chetan Mahajan](https://chetanmahajan.vercel.app/) [Software Developer]
+- [Chetan Mahajan](https://chetanmahajan.vercel.app) [Software Developer]
 - [Chetan Padia](https://chetbox.com)
 - [Chetanya Kandhari](https://availchet.github.io)
 - [Chethin Manage](https://www.cmanage.dev)
@@ -543,7 +542,6 @@ This repo can serve as inspiration for your portfolio!
 - [Dania Al-Hakim](https://pixeldania.netlify.app)
 - [Danial Khilji](https://danialkhilji.github.io/portfolio/) [Data Scientist | Machine Learning Engineer]
 - [Daniel Andrés Rodríguez](https://danrodd.dev) [Software Developer]
-- [Daniel Grazziotti](https://grazziotti-portfolio.vercel.app)
 - [Daniel Mark](https://thedanielmark.com)
 - [Daniel Michael](https://www.daniel-michael.com)
 - [Daniel Ortiz](https://danielortiz.web.app) [Full Stack Developer]
@@ -969,7 +967,6 @@ This repo can serve as inspiration for your portfolio!
 - [Kamil Mazurek](https://kamilmazurek.pl)
 - [Kamran Mushtaq](https://kamipresents.com) [Full Stack Developer]
 - [Karan Chhunchha](https://karanchhunchha.in) [Software Developer | AI Automation]
-- [Karrar Nazim](https://karrarnazim.space) [Full Stack Web Developer]
 - [Karthik Menon](https://www.karthikmenon.com)
 - [Karthik Shetty](http://karthikshetty.info) [Software Engineer | Full Stack Developer]
 - [Kartik Jain](https://jkartik.in) [‍ Backend Developer | Cybersecurity Enthusiast]
@@ -1022,7 +1019,6 @@ This repo can serve as inspiration for your portfolio!
 - [Kritan Shrestha](https://dev-kritan.github.io/portfolio/) [Full Stack Developer]
 - [Krupal Fataniya](https://krupal.vercel.app) [Full Stack Developer | Python, Django & React Specialist]
 - [Krupal Sanchaniya](https://krupal-portfolio.vercel.app) [Software Developer]
-- [Krushna Rathod](https://krushna.gridly.xyz) [UI/UX Designer]
 - [Ksv Muralidhar](https://ksvmuralidhar.in)
 - [Kuchizu](https://kuchizu.com) [DevOps Engineer]
 - [Kuei Poch Kuei](http://kueiyiee-portfolio.vercel.app) [Full Stack Dev and Creative Thinker]
@@ -1278,7 +1274,6 @@ This repo can serve as inspiration for your portfolio!
 - [Nanday Das](https://nandaydas.in) [Mobile App Developer]
 - [Naqqash](https://portfolionaqqash.vercel.app) [Full Stack 3D Developer]
 - [Narender Chepuri](https://narender24681.github.io) [Software Developer | Agentic AI & Real-Time Systems]
-- [Naresh Khatri](https://www.nareshkhatri.site)
 - [Naseem Khan](https://naseemkhan.dev) [Full Stack Developer | SaaS Builder | Freelancer]
 - [Natasha Pierre-Louis](https://www.natashasfolio.com) [Front-End Developer | Design Technologist | Ui/Ux Engineer]
 - [Nathan Simpson](https://nathansimpson.design)
@@ -1287,7 +1282,6 @@ This repo can serve as inspiration for your portfolio!
 - [Naveed Sohail Gung](https://naveed-gung.dev) [Software Engineer]
 - [Naveen Kumar Pasupuleti](https://naveens-portfolio-three.vercel.app) [Salesforce QA]
 - [Naveen Kumar](https://naveenweb.site) [Full Stack Developer | MERN Stack]
-- [NaveenKumar](https://naveenkumarm.space) [Full Stack Developer]
 - [Nayan Bobde](https://nayanbobde.github.io/Portfoliowebsite/) [Data Analyst | SQL | Power BI | Python | Azure]
 - [Nazia Shehnaz Joynab](https://geek-a-byte.github.io)
 - [Nazmus Sayad](https://sayad.dev)
@@ -1436,7 +1430,7 @@ This repo can serve as inspiration for your portfolio!
 - [Prem Gangadharan](https://premsg.info)
 - [Prem Kumar Rajbhar](https://premkrrajbhar.github.io/prem_kumar_rajbhar/) [Software Developer]
 - [Prem Prakash Sharma](https://premprakashsharma.vercel.app)
-- [Prem Thatikonda](https://premthatikonda.xyz/) [Full Stack & AI Engineer]
+- [Prem Thatikonda](https://premthatikonda.xyz) [Full Stack & AI Engineer]
 - [Prince Bhayani](https://princeb.dev) [Full Stack Developer]
 - [Pritam Debnath](https://pridebnath.github.io/portfolio-v2) [Frontend Developer]
 - [Pritu Yadav](https://prituyadav.github.io)
@@ -1643,7 +1637,7 @@ This repo can serve as inspiration for your portfolio!
 - [Sandeep Singh](https://portfolio-seven-bice-pdn04n7l52.vercel.app) [Full Stack Developer]
 - [Sanee Itas](https://saneeitas.netlify.app)
 - [Sangle Sudarshan](https://sanglesudarshan.vercel.app)
-- [Sanjana Venkatesh](https://sanjanavenkatesh.vercel.app/) [Backend Developer | Express.js & Django]
+- [Sanjana Venkatesh](https://sanjanavenkatesh.vercel.app) [Backend Developer | Express.js & Django]
 - [Sanjiv Thapa](https://portfolio.sanjivthapa.com.np/home) [Backend Developer]
 - [Sankalp Tharu](https://sankalptharu.com.np)
 - [Sanket Chaudhari](https://sanketchaudhari.in) [Full Stack Developer | AI & Data Science Engineer]
@@ -1663,7 +1657,6 @@ This repo can serve as inspiration for your portfolio!
 - [Satish Vaishnav](http://satishvaishnav.in)
 - [Satnam Singh](https://satnamsingh.in) [AI Engineer | Agentic GenAI Developer | Azure AI Foundry, Langraph & MCP]
 - [Satyam Gupta](https://imlolman.github.io)
-- [Saurabh Daware](https://www.saurabhdaware.in)
 - [Saurabh Nemade](https://www.nemade.eu) [Staff Engineer]
 - [Saurabh Patil](https://saurabhpatil.netlify.app) [Code Craftsman]
 - [Saurabh Singh](https://saurabh-works.netlify.app)
@@ -1690,7 +1683,7 @@ This repo can serve as inspiration for your portfolio!
 - [Seif Osman](https://seifosman.com) [IT Store Technology Engineer | Full Stack & Security]
 - [Serdar Salim](https://serdarsalim.com) [Automation Engineer]
 - [Sergei Chestakov](https://sergei.com)
-- [Sergio Jimenez](https://sergiojimenez.vercel.app/) [Full Stack Web Developer]
+- [Sergio Jimenez](https://sergiojimenez.vercel.app) [Full Stack Web Developer]
 - [Sergio Sanchez](https://sdsanchezm.github.io) [.Net And Java Dev]
 - [Serhii Nazarov](https://www.serhii-nazarov.com) [Senior Front-End | Full Stack Engineer]
 - [Seth Hall](https://sethhallcreative.com)
@@ -1815,7 +1808,7 @@ This repo can serve as inspiration for your portfolio!
 - [Suraj Kumar Nanda](https://www.surajkumarnanda.com) [Senior DevOps Engineer]
 - [Suraj Savle](https://surajsavle.in) [Full Stack Developer]
 - [Suraj Yadav](https://suraj-yadav0.github.io/terminal-portfolio/) [Software Engineer | Ubuntu Touch Developer]
-- [Sushant Mondal](https://www.sushantmondal.com/) [Computer Architect (RISC-V) / Hardware | System Administrator (IaaS and PaaS)]
+- [Sushant Mondal](https://www.sushantmondal.com) [Computer Architect (RISC-V) / Hardware | System Administrator (IaaS and PaaS)]
 - [Suvojit Konar](https://portfolio-ten-olive-gldao60wxb.vercel.app) [Senior Software Engineer | Backend Developer | AI Enthusiast]
 - [Swagata Ganguly](https://swagata.tech) [Full Stack Developer with GEN AI]
 - [Swarnava Dutta](https://swarnava.dev) [Lead AI Architect | Gen AI | Full Stack]

--- a/feed.json
+++ b/feed.json
@@ -328,10 +328,6 @@
     "tagline": "Software Engineer"
   },
   {
-    "name": "Abhishek Kandel",
-    "url": "https://abhishekkandel.com.np"
-  },
-  {
     "name": "Abhishek Panchal",
     "url": "https://skillstackpanchal.vercel.app"
   },
@@ -638,6 +634,11 @@
   {
     "name": "Ajvad Laseen",
     "url": "https://ajvadlaseen.com",
+    "tagline": "Full Stack Developer"
+  },
+  {
+    "name": "Ajyendu Chaudhary",
+    "url": "https://ajyendu.vercel.app",
     "tagline": "Full Stack Developer"
   },
   {
@@ -2015,6 +2016,10 @@
     "url": "https://multikitty.onrender.com"
   },
   {
+    "name": "Burhanaddin Mirsadizada",
+    "url": "https://burhanaddinzm.github.io"
+  },
+  {
     "name": "Cade Kynaston",
     "url": "https://cade.codes"
   },
@@ -2107,6 +2112,11 @@
     "tagline": "Student | Cyber Security"
   },
   {
+    "name": "Charles Degraeuwe",
+    "url": "https://charlesdegraeuwe.com",
+    "tagline": "Student | Full Stack Engineer"
+  },
+  {
     "name": "Charles Ouimet",
     "url": "https://ouimet.info",
     "tagline": "Backend Developer"
@@ -2114,6 +2124,11 @@
   {
     "name": "Charles Pustejovsky Iii",
     "url": "https://cpustejovsky.com"
+  },
+  {
+    "name": "Chetan Mahajan",
+    "url": "https://chetanmahajan.vercel.app",
+    "tagline": "Software Developer"
   },
   {
     "name": "Chetan Padia",
@@ -2322,10 +2337,6 @@
     "tagline": "Software Developer"
   },
   {
-    "name": "Daniel Grazziotti",
-    "url": "https://grazziotti-portfolio.vercel.app"
-  },
-  {
     "name": "Daniel Mark",
     "url": "https://thedanielmark.com"
   },
@@ -2394,6 +2405,11 @@
   {
     "name": "Daryl Cletus Fernandes",
     "url": "https://daryl-fernandes.com"
+  },
+  {
+    "name": "Dauren Abasov",
+    "url": "https://dadashi44.vercel.app",
+    "tagline": "Frontend Engineer"
   },
   {
     "name": "Daven Alajid",
@@ -4130,11 +4146,6 @@
     "tagline": "Software Developer | AI Automation"
   },
   {
-    "name": "Karrar Nazim",
-    "url": "https://karrarnazim.space",
-    "tagline": "Full Stack Web Developer"
-  },
-  {
     "name": "Karthik Menon",
     "url": "https://www.karthikmenon.com"
   },
@@ -4266,6 +4277,11 @@
     "tagline": "Software Engineer"
   },
   {
+    "name": "Kevin Iglesias",
+    "url": "https://iglesiaskevinralphbusiness.github.io",
+    "tagline": "Font-end Developer"
+  },
+  {
     "name": "Kevin Kenfack",
     "url": "https://kenfack-me.vercel.app"
   },
@@ -4369,11 +4385,6 @@
     "name": "Krupal Sanchaniya",
     "url": "https://krupal-portfolio.vercel.app",
     "tagline": "Software Developer"
-  },
-  {
-    "name": "Krushna Rathod",
-    "url": "https://krushna.gridly.xyz",
-    "tagline": "UI/UX Designer"
   },
   {
     "name": "Ksv Muralidhar",
@@ -5369,6 +5380,11 @@
     "tagline": "AI/ML Engineer | Full Stack Developer"
   },
   {
+    "name": "Muhammad Shamim Shoaib",
+    "url": "https://sshoaib.vercel.app",
+    "tagline": "Full Stack Developer"
+  },
+  {
     "name": "Muhammad Taha Nawab",
     "url": "https://taha-nawab-portfolio.vercel.app",
     "tagline": "Full Stack Developer · AI/ML Engineer"
@@ -5483,13 +5499,14 @@
     "tagline": "Mobile App Developer"
   },
   {
+    "name": "Naqqash",
+    "url": "https://portfolionaqqash.vercel.app",
+    "tagline": "Full Stack 3D Developer"
+  },
+  {
     "name": "Narender Chepuri",
     "url": "https://narender24681.github.io",
     "tagline": "Software Developer | Agentic AI & Real-Time Systems"
-  },
-  {
-    "name": "Naresh Khatri",
-    "url": "https://www.nareshkhatri.site"
   },
   {
     "name": "Naseem Khan",
@@ -5528,11 +5545,6 @@
     "name": "Naveen Kumar",
     "url": "https://naveenweb.site",
     "tagline": "Full Stack Developer | MERN Stack"
-  },
-  {
-    "name": "NaveenKumar",
-    "url": "https://naveenkumarm.space",
-    "tagline": "Full Stack Developer"
   },
   {
     "name": "Nayan Bobde",
@@ -5760,6 +5772,10 @@
     "name": "Olle Andreasson",
     "url": "https://oted.online",
     "tagline": "Staff Engineer"
+  },
+  {
+    "name": "Oluseye Oyewole",
+    "url": "https://www.oluseye.cv"
   },
   {
     "name": "Om Takale",
@@ -6159,6 +6175,11 @@
   {
     "name": "Prem Prakash Sharma",
     "url": "https://premprakashsharma.vercel.app"
+  },
+  {
+    "name": "Prem Thatikonda",
+    "url": "https://premthatikonda.xyz",
+    "tagline": "Full Stack & AI Engineer"
   },
   {
     "name": "Prince Bhayani",
@@ -6561,6 +6582,11 @@
   {
     "name": "Rishav",
     "url": "https://v0idrsh.vercel.app"
+  },
+  {
+    "name": "Rishhi Duetheesh",
+    "url": "https://rishhiduetheesh.netlify.app",
+    "tagline": "Frontend Developer"
   },
   {
     "name": "Ritesh Bucha",
@@ -7049,6 +7075,11 @@
     "url": "https://sanglesudarshan.vercel.app"
   },
   {
+    "name": "Sanjana Venkatesh",
+    "url": "https://sanjanavenkatesh.vercel.app",
+    "tagline": "Backend Developer | Express.js & Django"
+  },
+  {
     "name": "Sanjiv Thapa",
     "url": "https://portfolio.sanjivthapa.com.np/home",
     "tagline": "Backend Developer"
@@ -7131,10 +7162,6 @@
   {
     "name": "Satyam Gupta",
     "url": "https://imlolman.github.io"
-  },
-  {
-    "name": "Saurabh Daware",
-    "url": "https://www.saurabhdaware.in"
   },
   {
     "name": "Saurabh Nemade",
@@ -7253,6 +7280,11 @@
   {
     "name": "Sergei Chestakov",
     "url": "https://sergei.com"
+  },
+  {
+    "name": "Sergio Jimenez",
+    "url": "https://sergiojimenez.vercel.app",
+    "tagline": "Full Stack Web Developer"
   },
   {
     "name": "Sergio Sanchez",
@@ -7754,6 +7786,11 @@
     "url": "https://www.sudevmagar.tech"
   },
   {
+    "name": "Sudhir Yadav",
+    "url": "https://sudhiryadav-dev.vercel.app",
+    "tagline": "Full Stack Developer"
+  },
+  {
     "name": "Suhail Roushan",
     "url": "https://suhailroushan.com"
   },
@@ -7814,6 +7851,11 @@
     "name": "Suraj Yadav",
     "url": "https://suraj-yadav0.github.io/terminal-portfolio/",
     "tagline": "Software Engineer | Ubuntu Touch Developer"
+  },
+  {
+    "name": "Sushant Mondal",
+    "url": "https://www.sushantmondal.com",
+    "tagline": "Computer Architect (RISC-V) / Hardware | System Administrator (IaaS and PaaS)"
   },
   {
     "name": "Suvojit Konar",
@@ -8519,6 +8561,11 @@
     "name": "Wajahat Ali Mir",
     "url": "https://wajahat-ali-mir-dev.vercel.app",
     "tagline": "React Native Developer"
+  },
+  {
+    "name": "Waleed Ahmed",
+    "url": "https://waleedahmed.site",
+    "tagline": "Full Stack Developer | Typescript, Next.js, Node.js"
   },
   {
     "name": "Walker Smith",


### PR DESCRIPTION
## Summary
- Removes 7 portfolio entries whose links were flagged as broken by the link-checker bot in #4124
- All 7 verified independently as of 2026-08-22:
  - `abhishekkandel.com.np` — 404
  - `grazziotti-portfolio.vercel.app` — 503
  - `karrarnazim.space` — domain no longer resolves
  - `krushna.gridly.xyz` — 404
  - `naveenkumarm.space` — TLS handshake failure
  - `www.nareshkhatri.site` — TLS handshake failure
  - `www.saurabhdaware.in` — domain no longer resolves
- Portfolio count and feed.json regenerated by the repo's pre-commit hook

Fixes #4124

## Test plan
- [x] Verified each URL's failure independently via curl before removing
- [x] Confirmed removal follows the repo's established convention for dead-link issues (see prior commits like #4044, #4013)