### PR TITLE
Remove entries with broken portfolio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo can serve as inspiration for your portfolio!
 
 [Developer Portfolios Website](https://6e87v.hatchboxapp.com)
 
-## Current Portfolio Count: 1949
+## Current Portfolio Count: 1968
 
 **Jump to:** [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i)
 | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s)
@@ -99,7 +99,7 @@ This repo can serve as inspiration for your portfolio!
 - [Abhishek Panchal](https://skillstackpanchal.vercel.app)
 - [Abhishek Panthee](https://abhishekpanthee.com.np)
 - [Abhishek Sah](https://www.abhisheksah.dev) [Software Engineer]
-- [Abhishek Sharma](https://www.abhisheksharma.codes/) [Full Stack Developer | Software Engineer]
+- [Abhishek Sharma](https://www.abhisheksharma.codes) [Full Stack Developer | Software Engineer]
 - [Abhishek Singh](https://www.abhishekworks.com) [Full Stack Developer]
 - [Abinash Sharma](https://abinash-sharma.pages.dev) [Software Developer | MCA | Cloud | AI]
 - [Abraham Bankole](https://abrahambankole.dev)[Software Engineer | Full Stack Web Developer]
@@ -181,7 +181,6 @@ This repo can serve as inspiration for your portfolio!
 - [Akshay Santhoshkumar](https://akshaysanthoshkumar.vercel.app) [Full Stack 3D Software Developer]
 - [Akshay](https://devakshay.vercel.app)
 - [Al Amin](https://alamin-portfolio-site.vercel.app) [Full Stack Developer]
-- [Al Marzan](https://almarzancom.vercel.app) [Full Stack Developer]
 - [Alan Hamlett](https://ahamlett.com) [Founder & Ceo @Wakatime]
 - [Alan Khalili](https://www.alan-khalili.com)
 - [Alejandro Gomez](https://alejandro-gomez.vercel.app)
@@ -196,10 +195,8 @@ This repo can serve as inspiration for your portfolio!
 - [Alexis De Jesus](https://www.aalexis.fr) [Full Stack Developer]
 - [Alfred Dagenais](https://alfreddagenais.com)
 - [Ali Hamza](https://alihamza-fawn.vercel.app) [Full Stack Developer | MERN, Next.js, AWS & Web3]
-- [Ali Mohsin](https://www.ali-ch.dev) [Architect Of Ai-Driven Systems | Machine Learning, Security, And Full Stack Engineering]
 - [Ali Saleem](https://alisaleem252.com) [Web Developer & Web Programmer]
 - [Ali Younes](https://aliyounes.dev) [Software Engineer | Systems & Full Stack]
-- [Alif Jobaer](https://alifjobaer12.vercel.app) [Full Stack MERN & Next.js Developer | IoT & Algorithmic Problem Solving]
 - [Alishba Iqbal](https://alishbaiqbal123.vercel.app) [Software Engineer & Full Stack Developer]
 - [Allan Im](https://allanim.com) [Software Engineer]
 - [Allan Muturi](https://allanmuturi.vercel.app)
@@ -320,7 +317,6 @@ This repo can serve as inspiration for your portfolio!
 - [Arshad Mq](https://arshadmq.com) [Sr. Full Stack Developer And Freelancer]
 - [Arshdeep Singh](https://arshdeepsingh.me)
 - [Arslan Sarfraz](https://arslansarfraz.github.io/portfolio)
-- [Artem Okhten](https://okhten.com) [Applied Mathematics | Machine Learning & Software Engineering]
 - [Arthur Rasera](https://raseraa0.github.io) [Software Engineer]
 - [Artur Bień](https://expensive.toys) [Ui & Frontend Developer]
 - [Arup Mandal](https://arupmandal.github.io)
@@ -541,7 +537,6 @@ This repo can serve as inspiration for your portfolio!
 
 - [Dale French](https://dalefrench.dev)
 - [Dale Larroder](https://dalelarroder.com)
-- [Daljeet Singh](https://www.daljeetsingh.me)
 - [Damian Markowski](https://damianmarkowski.com)
 - [Damodar Kamani](https://damkam.vercel.app)
 - [Dania Al-Hakim](https://pixeldania.netlify.app)
@@ -646,7 +641,7 @@ This repo can serve as inspiration for your portfolio!
 
 - [Edgard Barquero Real](https://barquero.dev)
 - [Edikan Bassey](https://edikan-bassey.vercel.app) [Full Stack Developer]
-- [Edmund Spira](https://edmund.novyrix.com) [Systems Architect | Full-Stack Engineer]
+- [Edmund Spira](https://edmund.novyrix.com) [Systems Architect | Full Stack Engineer]
 - [Eduard-Constantin Ibinceanu](https://eduardconstantin.github.io)
 - [Ehsan Rafee](https://ehsanrafee.ir)
 - [Ekaterine Mitagvaria](https://ekaterine-mitagvaria.vercel.app)
@@ -781,7 +776,7 @@ This repo can serve as inspiration for your portfolio!
 - [Hafeez Mohamad](https://www.haffee.dev) [Software Engineer | Full Stack Developer | AI Engineer]
 - [Hafid Ziti](https://www.hafidziti.dev)
 - [Hafiq Iqmal](https://hafiq.dev) [Software Engineer | Backend & API Engineering | DevSecOps]
-- [Hafsa Salman](https://www.hafsasalman.com/) [Software Engineer | Full Stack Developer | AI]
+- [Hafsa Salman](https://www.hafsasalman.com) [Software Engineer | Full Stack Developer | AI]
 - [Hamish Williams](https://hamishw.com)
 - [Hamza Ehsan](https://www.hamzaehsan.com)
 - [Hamza Fareed](https://hamzafareed.vercel.app) [Full Stack AI Developer | React, Next.js, Node, Python, FastAPI]
@@ -917,7 +912,7 @@ This repo can serve as inspiration for your portfolio!
 - [Jerry Hirsch](https://jerryhirsch.com)
 - [Jeslor Ssozi](https://www.jeslor.com) [Full Stack Engineer]
 - [Jesus Santander](https://jsantanders.dev)
-- [Jetsadakorn Muangwichit](https://www.7sadakonr.xyz/) [Frontend-Focused Full-Stack Developer]
+- [Jetsadakorn Muangwichit](https://www.7sadakonr.xyz) [Frontend-Focused Full Stack Developer]
 - [Jhal Albert Berioso](https://portfolio.dwnppo.dev)
 - [Jhed Adrine Mendoza](https://jhedmendoza.is-a.dev)
 - [Jiban Budhathoki](https://jibanbudhathoki.com.np) [Software Engineer | Full Stack Developer]
@@ -1227,7 +1222,6 @@ This repo can serve as inspiration for your portfolio!
 - [Mohd Ubaid Khan](https://mdubaid.in) [Software Engineer | Full Stack Engineer | Problem Solver]
 - [Mohd Zaheer Uddin](https://sohailkhan0525.github.io/MyPortfolio) [MACHINE LEARNING BEGINNER | Founder of @Qofeno]
 - [Mohibur Rahman Sani](https://www.sanimohibur.me) [Full Stack Developer]
-- [Mohit Joe](https://mohitjoe.vercel.app)
 - [Mohit Kumar](https://mohit1r.github.io/Portfolio) [Cloud Native Software Engineer | Java | Spring Boot | Azure | DevOps]
 - [Mohit Paudyal](https://findmohit.netlify.app)
 - [Mohit Shrivastava](https://iamohit.com) [Senior Full Stack Engineer | Next.js Specialist]
@@ -1242,13 +1236,13 @@ This repo can serve as inspiration for your portfolio!
 - [Mudassir Junejo](https://mudassir-junejo.vercel.app) [AI Developer | Portfolio]
 - [Mufida Andi](https://heymufi.com) [Software Engineer | Frontend]
 - [Muhammad Aamir Malik](https://www.muhammadaamirmalik.com) [Full Stack Hybride App Developer]
-- [Muhammad Abdullah](https://abd-cloud-resume-v1.pages.dev/) [Cloud Engineering Student | AWS & Cloudflare]
+- [Muhammad Abdullah](https://abd-cloud-resume-v1.pages.dev) [Cloud Engineering Student | AWS & Cloudflare]
 - [Muhammad Adnan](https://portfolio-orpin-nu-27.vercel.app) [Full Stack Developer | MERN, Nextjs, Nestjs]
 - [Muhammad Ahmad](https://muhammadahmad.dev) [Full Stack Software Engineer | Blockchain & AI/LLM Engineer]
 - [Muhammad Azlaan Zubair](https://www.mdazlaanzubair.com) [Frontend Developer]
 - [Muhammad Faheem Iqbal Faheem506Pk](https://faheem506pk.vercel.app) [Frontend Developer | Mern Stack Developer | Iot Enthusiast]
-- [Muhammad Furqan](https://iammuhammadfurqan.github.io/portfolio/) [Full Stack AI Engineer | RAG & Voice AI Specialist]
 - [Muhammad Furqan Yasin](https://mfurqanyasin.com) [Full Stack Developer | AI Engineer]
+- [Muhammad Furqan](https://iammuhammadfurqan.github.io/portfolio/) [Full Stack AI Engineer | RAG & Voice AI Specialist]
 - [Muhammad Hassan Nazar](https://hassannazar72.github.io/portfolio/)
 - [Muhammad Iqbal Nazulis](https://iqbalnzls.github.io/portfolio/) [Software Engineer | Backend]
 - [Muhammad Jahanzeb](https://jahanzeb.dev) [Mobile App Developer | React Native | Expo | Kotlin | NodeJS]
@@ -1264,7 +1258,7 @@ This repo can serve as inspiration for your portfolio!
 - [Muhammad Ubaid Raza](https://mubaidr.js.org) [Sr. Software Engineer | Full Stack Developer | Chrome Extension Expert]
 - [Muhammed Ijlan](https://ijlan.dev)
 - [Muhammet Fatih Di̇Nç](https://mfatihdinc.com)
-- [Mujtaba Saqib](https://www.mujtabasaqib.com/) [Data Engineer | Data Scientist]
+- [Mujtaba Saqib](https://www.mujtabasaqib.com) [Data Engineer | Data Scientist]
 - [Mukesh](https://themukesh.com) [Java,React, next.js, Full Stack Developer]
 - [Mukul Chugh](https://mukulchugh.com)
 - [Munyaradzi Mzite](https://munyaradzimzite.vercel.app)[AI Graphics Engineer]
@@ -1335,10 +1329,10 @@ This repo can serve as inspiration for your portfolio!
 - [Nishmika Ekanayaka](https://nishmika-dev.vercel.app) [Full Stack Developer | Junior]
 - [Nitesh Nagpal](https://niteshnagpal.com)
 - [Nitesh Seram](https://niteshseram.in)
+- [Nithish Parameswaran](https://nithish.is-a.dev) [AI/ML engineer | Software Developer | Data Engineer]
 - [Nitika](https://my-portfolio-beryl-xi-81.vercel.app) [Graphic designer | Backend developer]
 - [Nitin Sahu](https://flawlessnitin.com) [Full Stack Engineer | Backend | Frontend]
 - [Nitish](https://nitishkr.fun)
-- [Nithish Parameswaran](https://nithish.is-a.dev) [AI/ML engineer | Software Developer | Data Engineer]
 - [Noaman Ahmed](https://noamanahmed.com)
 - [Noel Young](https://noeljyoung.github.io/portfolio/) [Senior Software Engineer | Laravel Developer | Go Enthusiast]
 - [Noor Rehman](https://www.noorrehman.me) [Data Scientist | AI Engineer | Freelancer]
@@ -1438,7 +1432,7 @@ This repo can serve as inspiration for your portfolio!
 - [Pranav Arya](https://pranavarya.in) [Software Engineer]
 - [Pranay Bandaru](https://pranaybandaru.vercel.app) [Data Science]
 - [Pranshu Patel](https://pranshu05.vercel.app)
-- [Prasad Jaagirdar](https://prasada-dev.netlify.app/)
+- [Prasad Jaagirdar](https://prasada-dev.netlify.app)
 - [Prashant Khandelwal](https://prashantk.dev)
 - [Prataya Silla](https://prataya-portfolio.vercel.app)
 - [Pratik Salunke](https://pratiksalunkeportfolio.vercel.app) [Aspiring Backend Developer | Python & Django]
@@ -1629,7 +1623,7 @@ This repo can serve as inspiration for your portfolio!
 - [Sairithik Komuravelly](https://heysai.dev) [Full Stack Engineer | AI Integration & Tooling]
 - [Saitheja Komalla](https://saitheja20.github.io/Portfolio)
 - [Sajid Alam](https://sajidalam.pages.dev) [Full Stack Developer]
-- [Sajjad Hossain Soykot](https://www.sajjadsoykot.me/) [Full-Stack Developer | System Designer]
+- [Sajjad Hossain Soykot](https://www.sajjadsoykot.me) [Full Stack Developer | System Designer]
 - [Sakib Mansuri](https://sakib-m.me) [Software engineer/AI developer]
 - [Sakib Rahman](https://rsakib.com) [Software Engineer]
 - [Saksham Agarwal](https://skshamagarwal.github.io)
@@ -1765,9 +1759,9 @@ This repo can serve as inspiration for your portfolio!
 - [Shubham Dey](https://shubhamdey01.github.io) [Student | AI/ML | Data Science]
 - [Shubham Gaur](https://shubhamessier.github.io/portfolio)
 - [Shubham Gupta](https://www.shubhamgupta.dev) [Senior Software Engineer | Full Stack Developer]
+- [Shubham Sharma](https://shubhamsharma.in) [Full Stack Developer]
 - [Shubham Tarade](https://coder-shanks.github.io)
 - [Shubham Vandara](https://shubhamvandara.netlify.app) [Full Stack Developer]
-- [Shubham Sharma](https://shubhamsharma.in) [Full Stack Developer]
 - [Shubhanshu Singh](https://shubhanshusingh.com) [Platform Engineer, Enterprise Architect, Founder @ exemplar.dev]
 - [Shushay Kebedew](https://shushaykebedew-portfolio.vercel.app) [Full Stack Developer]
 - [Shuvam Manna](http://shuvam.xyz)
@@ -1789,7 +1783,7 @@ This repo can serve as inspiration for your portfolio!
 - [Sohayel Mahmud](https://sohayelmahmud.github.io) [Computer Science Student| Competitive Programmer]
 - [Somenath Sau](https://somenathsau.github.io) [Data Analyst | gen AI | Cloud]
 - [Sonu Hansda](https://sonu-hansda.netlify.app) [Full Stack Developer]
-- [Sonu Suman Ojha](https://sonu-portfolio-1.netlify.app/) [Software Engineer]
+- [Sonu Suman Ojha](https://sonu-portfolio-1.netlify.app) [Software Engineer]
 - [Soufiane El Hamri](https://www.soufiane-elhamri.com) [Full Stack Developer]
 - [Souilah Moncef](https://moncef37i.github.io/portfolio/) [Full Stack Web Developer | Algeria]
 - [Soumya Jain](https://soumyajain.vercel.app) [Software Developer | AI Exgineering]
@@ -1833,7 +1827,7 @@ This repo can serve as inspiration for your portfolio!
 - [Suraj Kumar Nanda](https://www.surajkumarnanda.com) [Senior DevOps Engineer]
 - [Suraj Savle](https://surajsavle.in) [Full Stack Developer]
 - [Suraj Yadav](https://suraj-yadav0.github.io/terminal-portfolio/) [Software Engineer | Ubuntu Touch Developer]
-- [Surya Snata Panigrahi](https://suryaa-portfolio-eight.vercel.app/) [Software Developer]
+- [Surya Snata Panigrahi](https://suryaa-portfolio-eight.vercel.app) [Software Developer]
 - [Sushant Mondal](https://www.sushantmondal.com) [Computer Architect (RISC-V) / Hardware | System Administrator (IaaS and PaaS)]
 - [Suvojit Konar](https://portfolio-ten-olive-gldao60wxb.vercel.app) [Senior Software Engineer | Backend Developer | AI Enthusiast]
 - [Swagata Ganguly](https://swagata.tech) [Full Stack Developer with GEN AI]
@@ -1853,7 +1847,7 @@ This repo can serve as inspiration for your portfolio!
 ## T
 
 - [Tadashi Amano](https://tadashiamano.vercel.app)
-- [Taha Hassan](https://tahahassan.vercel.app/) [ML/DL Engineer & Frontend Developer | RAG · NLP · Predictive Modeling · React | End-to-end: model to UI]
+- [Taha Hassan](https://tahahassan.vercel.app) [ML/DL Engineer & Frontend Developer | RAG · NLP · Predictive Modeling · React | End-to-end: model to UI]
 - [Taiizor](https://github.com/Taiizor) [.Net Developer]
 - [Taiwo Bamidele](https://taiwobuilds.github.io/my-portfolio) [Frontend Developer]
 - [Talha Siddique](https://talhasiddique-portfolio.vercel.app) [AI Engineer | Full Stack Developer]
@@ -1869,7 +1863,6 @@ This repo can serve as inspiration for your portfolio!
 - [Tejas Jadhav](https://teeejaey.github.io)
 - [Tek Kshetri](http://tekkshetri.com.np)
 - [Thanh Tran](https://thanhtran-portfolio.vercel.app) [Software Engineer]
-- [Thea Choem](https://thea.juniorise.com)
 - [Thea Mushambadze](https://highflyer910.github.io)
 - [Thekaushikgoswami](https://thekaushikgoswami.github.io)
 - [Thiago Sousa](https://github.com/ThiagoSousa81) [Cryptographer - Full Stack Developer]
@@ -1887,7 +1880,7 @@ This repo can serve as inspiration for your portfolio!
 - [Tim Stanton](https://www.tim-stanton.dev)
 - [Timmy O'Mahony](https://timmyomahony.com) [Full Stack Developer]
 - [Tinotenda Mhedziso](https://tinotenda-mhedziso.pages.dev) [Software Developer]
-- [Tirth Dhedhi](https://www.tirthdhedhi.dev) [Full-Stack Developer]
+- [Tirth Dhedhi](https://www.tirthdhedhi.dev) [Full Stack Developer]
 - [Tj Klint](https://tjklint.github.io)
 - [Tomás Martinez](https://tomasmartinez.xyz)
 - [Tomáš Đinh](https://tomasdinh.cz) [Full Stack Developer]

--- a/feed.json
+++ b/feed.json
@@ -127,6 +127,10 @@
     "url": "https://www.aayushsood.com"
   },
   {
+    "name": "Abass Alzouma",
+    "url": "https://abass.wanecrea.com"
+  },
+  {
     "name": "Abbas Raza",
     "url": "https://abbasraza.dev",
     "tagline": "Software Engineer | Freelancer | AI & Blockchain Enthusiast"
@@ -339,6 +343,11 @@
     "name": "Abhishek Sah",
     "url": "https://www.abhisheksah.dev",
     "tagline": "Software Engineer"
+  },
+  {
+    "name": "Abhishek Sharma",
+    "url": "https://www.abhisheksharma.codes",
+    "tagline": "Full Stack Developer | Software Engineer"
   },
   {
     "name": "Abhishek Singh",
@@ -786,19 +795,14 @@
     "tagline": "Full Stack Developer | MERN, Next.js, AWS & Web3"
   },
   {
-    "name": "Ali Mohsin",
-    "url": "https://www.ali-ch.dev",
-    "tagline": "Architect Of Ai-Driven Systems | Machine Learning, Security, And Full Stack Engineering"
-  },
-  {
     "name": "Ali Saleem",
     "url": "https://alisaleem252.com",
     "tagline": "Web Developer & Web Programmer"
   },
   {
-    "name": "Alif Jobaer",
-    "url": "https://alifjobaer12.vercel.app",
-    "tagline": "Full Stack MERN & Next.js Developer | IoT & Algorithmic Problem Solving"
+    "name": "Ali Younes",
+    "url": "https://aliyounes.dev",
+    "tagline": "Software Engineer | Systems & Full Stack"
   },
   {
     "name": "Alishba Iqbal",
@@ -1353,11 +1357,6 @@
   {
     "name": "Arslan Sarfraz",
     "url": "https://arslansarfraz.github.io/portfolio"
-  },
-  {
-    "name": "Artem Okhten",
-    "url": "https://okhten.com",
-    "tagline": "Applied Mathematics | Machine Learning & Software Engineering"
   },
   {
     "name": "Arthur Rasera",
@@ -2316,10 +2315,6 @@
     "url": "https://dalelarroder.com"
   },
   {
-    "name": "Daljeet Singh",
-    "url": "https://www.daljeetsingh.me"
-  },
-  {
     "name": "Damian Markowski",
     "url": "https://damianmarkowski.com"
   },
@@ -2758,6 +2753,11 @@
     "name": "Edikan Bassey",
     "url": "https://edikan-bassey.vercel.app",
     "tagline": "Full Stack Developer"
+  },
+  {
+    "name": "Edmund Spira",
+    "url": "https://edmund.novyrix.com",
+    "tagline": "Systems Architect | Full Stack Engineer"
   },
   {
     "name": "Eduard-Constantin Ibinceanu",
@@ -3314,6 +3314,11 @@
     "name": "Hafiq Iqmal",
     "url": "https://hafiq.dev",
     "tagline": "Software Engineer | Backend & API Engineering | DevSecOps"
+  },
+  {
+    "name": "Hafsa Salman",
+    "url": "https://www.hafsasalman.com",
+    "tagline": "Software Engineer | Full Stack Developer | AI"
   },
   {
     "name": "Hamish Williams",
@@ -3903,6 +3908,11 @@
     "url": "https://jsantanders.dev"
   },
   {
+    "name": "Jetsadakorn Muangwichit",
+    "url": "https://www.7sadakonr.xyz",
+    "tagline": "Frontend-Focused Full Stack Developer"
+  },
+  {
     "name": "Jhal Albert Berioso",
     "url": "https://portfolio.dwnppo.dev"
   },
@@ -4208,6 +4218,11 @@
     "tagline": "Full Stack Developer | Cybersecurity Expert"
   },
   {
+    "name": "Kaushal Satam",
+    "url": "https://kaushal.dev",
+    "tagline": "Software Developer | Tech Nerd"
+  },
+  {
     "name": "Kaustubhai",
     "url": "https://kaustubhai.netlify.app"
   },
@@ -4238,6 +4253,11 @@
     "name": "Kavin",
     "url": "https://devekavin.github.io/Portfolio",
     "tagline": "Web Developer"
+  },
+  {
+    "name": "Kavy Sachaniya",
+    "url": "https://kavy-sachaniya.vercel.app",
+    "tagline": "Full Stack Developer | Student"
   },
   {
     "name": "Kay Evans-Stocks",
@@ -5264,10 +5284,6 @@
     "tagline": "Full Stack Developer"
   },
   {
-    "name": "Mohit Joe",
-    "url": "https://mohitjoe.vercel.app"
-  },
-  {
     "name": "Mohit Kumar",
     "url": "https://mohit1r.github.io/Portfolio",
     "tagline": "Cloud Native Software Engineer | Java | Spring Boot | Azure | DevOps"
@@ -5334,9 +5350,19 @@
     "tagline": "Full Stack Hybride App Developer"
   },
   {
+    "name": "Muhammad Abdullah",
+    "url": "https://abd-cloud-resume-v1.pages.dev",
+    "tagline": "Cloud Engineering Student | AWS & Cloudflare"
+  },
+  {
     "name": "Muhammad Adnan",
     "url": "https://portfolio-orpin-nu-27.vercel.app",
     "tagline": "Full Stack Developer | MERN, Nextjs, Nestjs"
+  },
+  {
+    "name": "Muhammad Ahmad",
+    "url": "https://muhammadahmad.dev",
+    "tagline": "Full Stack Software Engineer | Blockchain & AI/LLM Engineer"
   },
   {
     "name": "Muhammad Azlaan Zubair",
@@ -5347,6 +5373,11 @@
     "name": "Muhammad Faheem Iqbal Faheem506Pk",
     "url": "https://faheem506pk.vercel.app",
     "tagline": "Frontend Developer | Mern Stack Developer | Iot Enthusiast"
+  },
+  {
+    "name": "Muhammad Furqan Yasin",
+    "url": "https://mfurqanyasin.com",
+    "tagline": "Full Stack Developer | AI Engineer"
   },
   {
     "name": "Muhammad Furqan",
@@ -5421,6 +5452,11 @@
   {
     "name": "Muhammet Fatih Di̇Nç",
     "url": "https://mfatihdinc.com"
+  },
+  {
+    "name": "Mujtaba Saqib",
+    "url": "https://www.mujtabasaqib.com",
+    "tagline": "Data Engineer | Data Scientist"
   },
   {
     "name": "Mukesh",
@@ -5723,6 +5759,11 @@
   {
     "name": "Nitesh Seram",
     "url": "https://niteshseram.in"
+  },
+  {
+    "name": "Nithish Parameswaran",
+    "url": "https://nithish.is-a.dev",
+    "tagline": "AI/ML engineer | Software Developer | Data Engineer"
   },
   {
     "name": "Nitika",
@@ -6055,6 +6096,11 @@
     "tagline": "Full Stack Developer"
   },
   {
+    "name": "Philo Sanjay Chamberline",
+    "url": "https://philotheephilix.in",
+    "tagline": "AI and Web3 Engineer"
+  },
+  {
     "name": "Phpxcoder",
     "url": "https://phpxcoder.in"
   },
@@ -6148,6 +6194,10 @@
     "url": "https://pranshu05.vercel.app"
   },
   {
+    "name": "Prasad Jaagirdar",
+    "url": "https://prasada-dev.netlify.app"
+  },
+  {
     "name": "Prashant Khandelwal",
     "url": "https://prashantk.dev"
   },
@@ -6221,6 +6271,11 @@
   {
     "name": "Priyanshu Chauhan",
     "url": "https://priyanshuportfolioo.netlify.app",
+    "tagline": "Full Stack Developer"
+  },
+  {
+    "name": "Priyanshu Ghosh",
+    "url": "https://priyanshu-ghosh-seven.vercel.app",
     "tagline": "Full Stack Developer"
   },
   {
@@ -6960,6 +7015,11 @@
     "tagline": "Full Stack Developer"
   },
   {
+    "name": "Sajjad Hossain Soykot",
+    "url": "https://www.sajjadsoykot.me",
+    "tagline": "Full Stack Developer | System Designer"
+  },
+  {
     "name": "Sakib Mansuri",
     "url": "https://sakib-m.me",
     "tagline": "Software engineer/AI developer"
@@ -7155,6 +7215,11 @@
     "name": "Sarthak Bhushan",
     "url": "https://portfolio-ten-gules-teouuqn2p2.vercel.app",
     "tagline": "Backend Developer | Spring Boot | React"
+  },
+  {
+    "name": "Sarthak Sharma",
+    "url": "https://sarthak-mac.vercel.app",
+    "tagline": "Full Stack Developer & Mobile Application Developer, DevOPS"
   },
   {
     "name": "Saswata Dutta",
@@ -7434,6 +7499,11 @@
     "tagline": "Full Stack Developer"
   },
   {
+    "name": "Shaun Fischmann",
+    "url": "https://heyshaun.fr",
+    "tagline": "Partnership Manager | Web Developer | Proptech"
+  },
+  {
     "name": "Shaun Furtado",
     "url": "https://shaunfurtado.is-a.dev"
   },
@@ -7566,6 +7636,11 @@
     "tagline": "Senior Software Engineer | Full Stack Developer"
   },
   {
+    "name": "Shubham Sharma",
+    "url": "https://shubhamsharma.in",
+    "tagline": "Full Stack Developer"
+  },
+  {
     "name": "Shubham Tarade",
     "url": "https://coder-shanks.github.io"
   },
@@ -7670,6 +7745,11 @@
     "name": "Sonu Hansda",
     "url": "https://sonu-hansda.netlify.app",
     "tagline": "Full Stack Developer"
+  },
+  {
+    "name": "Sonu Suman Ojha",
+    "url": "https://sonu-portfolio-1.netlify.app",
+    "tagline": "Software Engineer"
   },
   {
     "name": "Soufiane El Hamri",
@@ -7868,6 +7948,11 @@
     "tagline": "Software Engineer | Ubuntu Touch Developer"
   },
   {
+    "name": "Surya Snata Panigrahi",
+    "url": "https://suryaa-portfolio-eight.vercel.app",
+    "tagline": "Software Developer"
+  },
+  {
     "name": "Sushant Mondal",
     "url": "https://www.sushantmondal.com",
     "tagline": "Computer Architect (RISC-V) / Hardware | System Administrator (IaaS and PaaS)"
@@ -7944,6 +8029,11 @@
     "url": "https://tadashiamano.vercel.app"
   },
   {
+    "name": "Taha Hassan",
+    "url": "https://tahahassan.vercel.app",
+    "tagline": "ML/DL Engineer & Frontend Developer | RAG · NLP · Predictive Modeling · React | End-to-end: model to UI"
+  },
+  {
     "name": "Taiizor",
     "url": "https://github.com/Taiizor",
     "tagline": ".Net Developer"
@@ -8011,10 +8101,6 @@
     "name": "Thanh Tran",
     "url": "https://thanhtran-portfolio.vercel.app",
     "tagline": "Software Engineer"
-  },
-  {
-    "name": "Thea Choem",
-    "url": "https://thea.juniorise.com"
   },
   {
     "name": "Thea Mushambadze",
@@ -8091,6 +8177,11 @@
     "name": "Tinotenda Mhedziso",
     "url": "https://tinotenda-mhedziso.pages.dev",
     "tagline": "Software Developer"
+  },
+  {
+    "name": "Tirth Dhedhi",
+    "url": "https://www.tirthdhedhi.dev",
+    "tagline": "Full Stack Developer"
   },
   {
     "name": "Tj Klint",
@@ -8202,6 +8293,11 @@
   {
     "name": "Umesh Nagare",
     "url": "https://umeshnagare.com"
+  },
+  {
+    "name": "Ummay Maimona Chaman",
+    "url": "https://ummaymaimonachaman.github.io/Myself_CHAMAN/",
+    "tagline": "AI Researcher | Full Stack Developer"
   },
   {
     "name": "Usman Ghias",


### PR DESCRIPTION
## Summary
- Verified each URL from the #4153 broken links report by hand before removing anything.
- Removed the 7 entries whose links are confirmed dead:
  - Al Marzan — almarzancom.vercel.app (404)
  - Ali Mohsin — www.ali-ch.dev (402, deployment disabled)
  - Alif Jobaer — alifjobaer12.vercel.app (redirects to a domain that fails to connect)
  - Artem Okhten — okhten.com (402, deployment disabled)
  - Daljeet Singh — www.daljeetsingh.me (404)
  - Mohit Joe — mohitjoe.vercel.app (404)
  - Thea Choem — thea.juniorise.com (TLS handshake failure)
- Left Keith Lau's entry in place — its 503 in the report was a transient error; the site returns 200 on repeated checks.
- `feed.json` and the portfolio count were regenerated automatically by the pre-commit hook.

Closes #4153

## Test plan
- [x] Manually curled all 8 reported URLs to confirm status before editing
- [x] Re-checked Keith Lau's URL multiple times to rule out a transient failure